### PR TITLE
Redesign shell layout with sidebar navigation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -73,7 +73,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1483,7 +1482,6 @@
       "integrity": "sha512-+kLxJpaJzXybyDyFXYADyP1cznTO8HSuBpenGlnKOAkH4hyNINiywvXS/tGJhsrGGP/gM185RA3xpjY0Yg4erA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1525,7 +1523,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1749,7 +1746,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -2079,7 +2075,6 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2695,7 +2690,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3149,7 +3143,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3197,7 +3190,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3380,7 +3372,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3390,7 +3381,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -3830,7 +3820,6 @@
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -3990,7 +3979,6 @@
       "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -4194,7 +4182,6 @@
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/frontend/src/components/Shell.jsx
+++ b/frontend/src/components/Shell.jsx
@@ -1,87 +1,205 @@
 // frontend/src/components/Shell.jsx
-import { LogOut, NotebookPen, Menu } from "lucide-react";
+import { LogOut, NotebookPen, Menu, Plus, X } from "lucide-react";
 import { Link, useLocation } from "react-router-dom";
 import { useAuth } from "../context/AuthProvider";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
-export default function Shell({ children, tabs }) {
+export default function Shell({
+  children,
+  tabs,
+  title,
+  description,
+  addNewLabel = "Add new",
+  onAddNew,
+  headerActions,
+}) {
   const { user, logout } = useAuth();
   const { pathname } = useLocation();
-  const [openMenu, setOpenMenu] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const currentTab = useMemo(() => {
+    if (!tabs?.length) return null;
+    return (
+      tabs.find((t) => pathname === t.to) ||
+      tabs.find((t) => pathname.startsWith(t.to)) ||
+      tabs[0]
+    );
+  }, [pathname, tabs]);
+
+  const displayTitle = title || currentTab?.label || "Panel";
+  const displayDescription =
+    description ||
+    (user
+      ? `Sesión activa de ${user.nombre}`
+      : "Organizá la información académica");
+
+  const initials = useMemo(() => {
+    if (!user?.nombre) return "CD";
+    return user.nombre
+      .split(" ")
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((segmento) => segmento[0]?.toUpperCase())
+      .join("");
+  }, [user?.nombre]);
+
+  function handleAddNew() {
+    if (onAddNew) onAddNew();
+  }
+
+  const AddNewButton = ({ variant = "solid", className = "" }) => (
+    <button
+      type="button"
+      onClick={handleAddNew}
+      disabled={!onAddNew}
+      className={
+        "inline-flex items-center justify-center gap-2 rounded-2xl px-4 py-2.5 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-300 disabled:cursor-not-allowed disabled:opacity-60 " +
+        (variant === "solid"
+          ? "bg-brand-500 text-white shadow-md hover:bg-brand-600"
+          : "bg-gradient-to-r from-brand-500 to-brand-400 text-white shadow-lg hover:from-brand-500/90 hover:to-brand-400/90") +
+        (className ? ` ${className}` : "")
+      }
+    >
+      <Plus className="h-4 w-4" aria-hidden="true" />
+      <span>{addNewLabel}</span>
+    </button>
+  );
+
+  const menuItems = (tabs || []).map((t) => {
+    const active = pathname === t.to || pathname.startsWith(`${t.to}/`);
+    return (
+      <Link
+        key={t.to}
+        to={t.to}
+        onClick={() => setSidebarOpen(false)}
+        className={
+          "block rounded-xl px-4 py-2 text-sm font-medium transition " +
+          (active
+            ? "bg-brand-100 text-brand-700 shadow-sm"
+            : "text-slate-500 hover:bg-slate-100")
+        }
+      >
+        {t.label}
+      </Link>
+    );
+  });
+
+  const SidebarContent = ({ showClose }) => (
+    <aside className="flex h-full w-72 flex-col bg-white shadow-xl">
+      <div className="flex items-center justify-between gap-3 px-6 pt-7 pb-4 border-b border-slate-200">
+        <div className="flex items-center gap-3">
+          <div className="grid h-10 w-10 place-items-center rounded-2xl bg-brand-500 text-white shadow-lg">
+            <NotebookPen className="h-5 w-5" aria-hidden="true" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold text-slate-900">Cuaderno Digital</p>
+            <p className="text-xs text-slate-500">{user?.rol ? `Rol: ${user.rol}` : "Gestión escolar"}</p>
+          </div>
+        </div>
+        {showClose && (
+          <button
+            type="button"
+            onClick={() => setSidebarOpen(false)}
+            className="rounded-full p-1 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700"
+            aria-label="Cerrar menú"
+          >
+            <X className="h-5 w-5" aria-hidden="true" />
+          </button>
+        )}
+      </div>
+
+      <div className="px-6 pt-5">
+        <AddNewButton variant="gradient" className="w-full" />
+      </div>
+
+      <nav className="flex-1 space-y-1 overflow-y-auto px-4 py-6">
+        {menuItems.length > 0 ? menuItems : (
+          <span className="block rounded-xl bg-slate-50 px-4 py-2 text-sm text-slate-400">
+            Sin secciones disponibles
+          </span>
+        )}
+      </nav>
+
+      <div className="border-t border-slate-200 px-6 py-6">
+        <button
+          type="button"
+          onClick={logout}
+          className="flex w-full items-center justify-center gap-2 rounded-xl border border-transparent bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-300"
+        >
+          <LogOut className="h-4 w-4" aria-hidden="true" />
+          <span>Salir</span>
+        </button>
+      </div>
+    </aside>
+  );
 
   return (
-    <div className="min-h-screen grid grid-rows-[auto,1fr]">
-      <header className="bg-surface2/95 border-b border-muted backdrop-blur supports-[backdrop-filter]:bg-surface2/75">
-        <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <div className="h-9 w-9 rounded-xl bg-brand-600 grid place-items-center shadow-soft">
-              <NotebookPen className="h-5 w-5 text-white" aria-hidden="true" />
+    <div className="min-h-screen bg-slate-100 text-slate-800">
+      <div className="flex min-h-screen">
+        <div className="hidden lg:flex lg:shrink-0">
+          <SidebarContent showClose={false} />
+        </div>
+
+        {sidebarOpen && (
+          <div className="fixed inset-0 z-40 flex lg:hidden">
+            <div
+              className="absolute inset-0 bg-slate-900/40"
+              aria-hidden="true"
+              onClick={() => setSidebarOpen(false)}
+            />
+            <div className="relative ml-auto h-full w-72 max-w-full">
+              <SidebarContent showClose />
             </div>
-            <div>
-              <div className="font-semibold">Cuaderno Digital</div>
-              <div className="text-xs text-subtext">
-                Sesión: {user?.nombre} — <span className="uppercase">{user?.rol}</span>
+          </div>
+        )}
+
+        <main className="flex min-h-screen flex-1 flex-col">
+          <div className="border-b border-slate-200 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/70">
+            <div className="flex flex-col gap-4 px-5 py-4 sm:px-8 sm:py-5 lg:flex-row lg:items-center lg:justify-between">
+              <div className="flex items-start gap-4">
+                <button
+                  type="button"
+                  onClick={() => setSidebarOpen(true)}
+                  className="rounded-2xl border border-slate-200 bg-white p-2 text-slate-600 shadow-sm transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-300 lg:hidden"
+                  aria-label="Abrir menú"
+                >
+                  <Menu className="h-5 w-5" aria-hidden="true" />
+                </button>
+
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                    Inicio · {currentTab?.label || "Panel"}
+                  </p>
+                  <h1 className="mt-1 text-2xl font-semibold text-slate-900 sm:text-3xl">
+                    {displayTitle}
+                  </h1>
+                  <p className="mt-1 text-sm text-slate-500">{displayDescription}</p>
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                {headerActions}
+                <AddNewButton className="w-full sm:w-auto" />
+                <div className="flex items-center gap-3 rounded-2xl border border-slate-200 bg-white px-3 py-2 shadow-sm">
+                  <div className="text-right">
+                    <p className="text-sm font-semibold text-slate-800">{user?.nombre || "Usuario"}</p>
+                    <p className="text-xs uppercase text-slate-400">{user?.rol || "Invitado"}</p>
+                  </div>
+                  <div className="grid h-10 w-10 place-items-center rounded-full bg-brand-100 text-brand-600 font-semibold">
+                    {initials}
+                  </div>
+                </div>
               </div>
             </div>
           </div>
 
-          <nav className="hidden sm:flex items-center gap-2">
-            {(tabs || []).map(t => {
-              const active = pathname === t.to;
-              return (
-                <Link
-                  key={t.to}
-                  to={t.to}
-                  className={"px-3 py-2 rounded-xl transition " + (active ? "bg-brand-500 text-black font-semibold":"hover:bg-muted")}
-                >
-                  {t.label}
-                </Link>
-              );
-            })}
-          </nav>
-
-          <div className="flex items-center gap-2">
-            <button
-              onClick={logout}
-              className="hidden sm:inline-flex items-center gap-2 bg-brand-500 hover:bg-brand-600 text-black font-semibold px-3 py-2 rounded-xl transition shadow-soft"
-            >
-              ⤴ Salir
-            </button>
-            <button className="sm:hidden" aria-label="Abrir menú" onClick={() => setOpenMenu(v => !v)}>
-              <Menu />
-            </button>
-          </div>
-        </div>
-
-        {openMenu && (
-          <div className="sm:hidden border-t border-muted bg-surface2">
-            <div className="max-w-6xl mx-auto px-4 py-2 flex flex-col gap-1">
-              {(tabs || []).map(t => (
-                <Link
-                  key={t.to}
-                  to={t.to}
-                  onClick={() => setOpenMenu(false)}
-                  className={"px-3 py-2 rounded-xl hover:bg-muted " + (pathname === t.to ? "bg-brand-500 text-black font-semibold" : "")}
-                >
-                  {t.label}
-                </Link>
-              ))}
-              <button
-                onClick={logout}
-                className="mt-1 px-3 py-2 rounded-xl bg-brand-500 text-black font-semibold"
-              >
-                Salir
-              </button>
+          <div className="flex-1 px-5 py-6 sm:px-8 sm:py-8">
+            <div className="mx-auto w-full max-w-6xl">
+              {children}
             </div>
           </div>
-        )}
-      </header>
-
-      <main>
-        <div className="max-w-6xl mx-auto px-4 py-6">
-          {children}
-        </div>
-      </main>
+        </main>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -85,12 +85,22 @@ export default function Dashboard() {
     }
   }
 
+  const cursoActual = cursos.find((c) => c._id === cursoSel);
+
   return (
     <Shell
       tabs={[
         { to: "/", label: "Inicio" },
         { to: "/asistencia", label: "Asistencia" },
       ]}
+      title="Panel principal"
+      description={
+        cursoActual
+          ? `Curso seleccionado: ${cursoActual.nombre} — ${cursoActual.anio}° ${cursoActual.division || ""}`
+          : "Resumen general de novedades y cursos"
+      }
+      addNewLabel="Nuevo anuncio"
+      onAddNew={esCreador ? () => setOpenNew(true) : undefined}
     >
       {/* Resumen superior */}
       <div className="grid md:grid-cols-2 gap-4 mb-6">
@@ -98,11 +108,6 @@ export default function Dashboard() {
           <CardHeader
             title="Tus cursos"
             subtitle="Seleccioná para ver anuncios"
-            actions={
-              esCreador && cursos.length > 0 && (
-                <Button onClick={() => setOpenNew(true)}>Nuevo anuncio</Button>
-              )
-            }
           />
           <CardBody>
             {loading ? (


### PR DESCRIPTION
## Summary
- redesign the Shell component into a flexible layout with a fixed sidebar, responsive drawer, and updated light styling
- add a contextual main header with breadcrumb, avatar, and CTA handling within the Shell
- update the dashboard to surface its metadata and Nuevo anuncio action through the new Shell API

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e30c568b58832484c97ded132178d4