### PR TITLE
Refactor dashboard layout with reusable components

### DIFF
--- a/frontend/src/components/dashboard/AnnouncementCard.jsx
+++ b/frontend/src/components/dashboard/AnnouncementCard.jsx
@@ -1,0 +1,95 @@
+import { MoreHorizontal } from "lucide-react";
+import Badge from "../ui/Badge";
+
+const palettes = {
+  sky: {
+    bg: "bg-sky-50",
+    border: "border-sky-100",
+    accent: "text-sky-900",
+    dot: "bg-sky-200",
+  },
+  rose: {
+    bg: "bg-rose-50",
+    border: "border-rose-100",
+    accent: "text-rose-900",
+    dot: "bg-rose-200",
+  },
+  amber: {
+    bg: "bg-amber-50",
+    border: "border-amber-100",
+    accent: "text-amber-900",
+    dot: "bg-amber-200",
+  },
+  teal: {
+    bg: "bg-teal-50",
+    border: "border-teal-100",
+    accent: "text-teal-900",
+    dot: "bg-teal-200",
+  },
+};
+
+export default function AnnouncementCard({
+  title,
+  summary,
+  date,
+  author,
+  audience,
+  course,
+  tone = "sky",
+  loading = false,
+}) {
+  if (loading) {
+    return (
+      <article className="rounded-3xl border border-muted/40 bg-surface/60 p-6 animate-pulse space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="h-4 w-24 rounded-full bg-muted/60" />
+          <div className="h-4 w-12 rounded-full bg-muted/60" />
+        </div>
+        <div className="h-6 w-3/4 rounded-full bg-muted/60" />
+        <div className="space-y-2">
+          <div className="h-3 w-full rounded-full bg-muted/50" />
+          <div className="h-3 w-5/6 rounded-full bg-muted/50" />
+          <div className="h-3 w-2/3 rounded-full bg-muted/50" />
+        </div>
+        <div className="h-3 w-20 rounded-full bg-muted/60" />
+      </article>
+    );
+  }
+
+  const palette = palettes[tone] ?? palettes.sky;
+
+  return (
+    <article
+      className={`relative flex h-full flex-col justify-between gap-4 rounded-3xl border p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md ${palette.bg} ${palette.border}`}
+    >
+      <div className="absolute right-6 top-6">
+        <button
+          type="button"
+          className="rounded-full p-1 text-subtext/60 transition hover:bg-white/60 hover:text-subtext focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-300"
+        >
+          <MoreHorizontal className="h-5 w-5" aria-hidden="true" />
+        </button>
+      </div>
+      <div className="flex items-center gap-2 text-xs text-subtext/80">
+        {course ? <span className="font-medium">{course}</span> : null}
+        {course && date ? <span>•</span> : null}
+        {date ? <span>{date}</span> : null}
+      </div>
+      <div>
+        <h3 className={`text-lg font-semibold leading-tight ${palette.accent}`}>{title}</h3>
+        {summary ? (
+          <p className="mt-2 text-sm text-subtext/90">
+            {summary}
+          </p>
+        ) : null}
+      </div>
+      <div className="flex items-center justify-between text-xs text-subtext/80">
+        <div className="flex items-center gap-2">
+          <span className={`h-2 w-2 rounded-full ${palette.dot}`} aria-hidden="true" />
+          <span>{author}</span>
+        </div>
+        {audience ? <Badge color="neutral">{audience}</Badge> : null}
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/components/dashboard/RecentTile.jsx
+++ b/frontend/src/components/dashboard/RecentTile.jsx
@@ -1,0 +1,64 @@
+import { Loader2 } from "lucide-react";
+
+const palettes = {
+  sky: {
+    base: "bg-sky-50 border-sky-100 hover:border-sky-200",
+    active: "ring-2 ring-sky-200",
+    icon: "bg-sky-100 text-sky-600",
+    accent: "text-sky-900",
+  },
+  rose: {
+    base: "bg-rose-50 border-rose-100 hover:border-rose-200",
+    active: "ring-2 ring-rose-200",
+    icon: "bg-rose-100 text-rose-600",
+    accent: "text-rose-900",
+  },
+  amber: {
+    base: "bg-amber-50 border-amber-100 hover:border-amber-200",
+    active: "ring-2 ring-amber-200",
+    icon: "bg-amber-100 text-amber-600",
+    accent: "text-amber-900",
+  },
+  teal: {
+    base: "bg-teal-50 border-teal-100 hover:border-teal-200",
+    active: "ring-2 ring-teal-200",
+    icon: "bg-teal-100 text-teal-600",
+    accent: "text-teal-900",
+  },
+};
+
+export default function RecentTile({
+  icon: Icon,
+  title,
+  subtitle,
+  tone = "sky",
+  active = false,
+  onClick,
+  loading = false,
+}) {
+  if (loading) {
+    return (
+      <div className="h-32 rounded-3xl border border-muted/40 bg-surface/40 animate-pulse" />
+    );
+  }
+
+  const palette = palettes[tone] ?? palettes.sky;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`relative flex h-32 w-full flex-col justify-between rounded-3xl border p-5 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand-300 ${palette.base} ${active ? palette.active : ""}`}
+    >
+      <span className={`inline-flex h-10 w-10 items-center justify-center rounded-2xl text-lg ${palette.icon}`}>
+        {Icon ? <Icon className="h-5 w-5" aria-hidden="true" /> : <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />}
+      </span>
+      <div>
+        <p className={`text-sm font-semibold ${palette.accent}`}>{title}</p>
+        {subtitle ? (
+          <p className="text-xs text-subtext/80">{subtitle}</p>
+        ) : null}
+      </div>
+    </button>
+  );
+}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,17 +1,20 @@
 // frontend/src/pages/Dashboard.jsx
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { BookOpen, CalendarDays, Megaphone, Plus } from "lucide-react";
+
 import { useAuth } from "../context/AuthProvider";
 import { apiGet, apiPost } from "../api";
 import Shell from "../components/Shell";
 import Button from "../components/ui/Button";
-import { Card, CardHeader, CardBody } from "../components/ui/Card";
-import Badge from "../components/ui/Badge";
 import Modal from "../components/ui/Modal";
 import { useToast } from "../components/ui/Toast";
-import { Megaphone, CalendarDays } from "lucide-react";
 import Select from "../components/ui/Select";
 import EmptyState from "../components/ui/EmptyState";
 import Input from "../components/ui/Input";
+import RecentTile from "../components/dashboard/RecentTile";
+import AnnouncementCard from "../components/dashboard/AnnouncementCard";
+
+const tonePalette = ["sky", "rose", "amber", "teal"];
 
 export default function Dashboard() {
   const { user } = useAuth();
@@ -20,9 +23,9 @@ export default function Dashboard() {
   const [cursos, setCursos] = useState([]);
   const [cursoSel, setCursoSel] = useState("");
   const [anuncios, setAnuncios] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [loadingCursos, setLoadingCursos] = useState(true);
+  const [loadingAnuncios, setLoadingAnuncios] = useState(true);
 
-  // Modal "Nuevo anuncio"
   const [openNew, setOpenNew] = useState(false);
   const [titulo, setTitulo] = useState("");
   const [contenido, setContenido] = useState("");
@@ -31,29 +34,38 @@ export default function Dashboard() {
 
   const esCreador = user?.rol === "admin" || user?.rol === "docente";
 
-  // Cargar cursos
   useEffect(() => {
     (async () => {
-      setLoading(true);
+      setLoadingCursos(true);
       try {
         const list = await apiGet("/api/cursos");
         setCursos(list);
-        if (list[0]?._id) setCursoSel(list[0]._id);
+        if (list[0]?._id) {
+          setCursoSel((prev) => prev || list[0]._id);
+        }
       } finally {
-        setLoading(false);
+        setLoadingCursos(false);
       }
     })();
   }, []);
 
-  // Cargar anuncios del curso
   useEffect(() => {
-    if (!cursoSel) return;
+    if (!cursoSel) {
+      setAnuncios([]);
+      setLoadingAnuncios(false);
+      return;
+    }
     (async () => {
+      setLoadingAnuncios(true);
       try {
         const list = await apiGet(`/api/anuncios?curso=${cursoSel}`);
         list.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
         setAnuncios(list);
-      } catch { /* toasts por api.js */ }
+      } catch {
+        setAnuncios([]);
+      } finally {
+        setLoadingAnuncios(false);
+      }
     })();
   }, [cursoSel]);
 
@@ -85,6 +97,11 @@ export default function Dashboard() {
     }
   }
 
+  const cursoActual = useMemo(
+    () => cursos.find((curso) => curso._id === cursoSel),
+    [cursos, cursoSel],
+  );
+
   return (
     <Shell
       tabs={[
@@ -92,89 +109,157 @@ export default function Dashboard() {
         { to: "/asistencia", label: "Asistencia" },
       ]}
     >
-      {/* Resumen superior */}
-      <div className="grid md:grid-cols-2 gap-4 mb-6">
-        <Card>
-          <CardHeader
-            title="Tus cursos"
-            subtitle="Seleccioná para ver anuncios"
-            actions={
-              esCreador && cursos.length > 0 && (
-                <Button onClick={() => setOpenNew(true)}>Nuevo anuncio</Button>
-              )
-            }
-          />
-          <CardBody>
-            {loading ? (
-              <div className="text-subtext">Cargando cursos…</div>
-            ) : cursos.length === 0 ? (
-              <div className="text-subtext">No hay cursos.</div>
-            ) : (
-              <Select value={cursoSel} onChange={(e)=>setCursoSel(e.target.value)} className="max-w-md">
-                {cursos.map((c) => (
-                  <option key={c._id} value={c._id}>
-                    {c.nombre} — {c.anio}° {c.division || ""}
-                  </option>
-                ))}
-              </Select>
-            )}
-          </CardBody>
-        </Card>
-
-        <Card>
-          <CardHeader title="Calendario escolar" subtitle="Próximos eventos" />
-          <CardBody>
-            <div className="flex items-center gap-3 text-subtext">
-              <CalendarDays className="h-5 w-5" aria-hidden="true" />
-              <div>Muy pronto: agenda de actos y reuniones</div>
+      <div className="space-y-10">
+        <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="space-y-1">
+            <h1 className="text-2xl font-semibold text-text">¡Hola {user?.nombre || ""}!</h1>
+            <p className="text-sm text-subtext">
+              Revisá las novedades de tus cursos y organizá tus comunicaciones desde un mismo lugar.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            {esCreador ? (
+              <Button onClick={() => setOpenNew(true)}>
+                <Plus className="mr-2 h-4 w-4" aria-hidden="true" />
+                Nuevo anuncio
+              </Button>
+            ) : null}
+            <div className="flex items-center gap-2 rounded-full bg-surface px-4 py-2 text-xs text-subtext/80">
+              <CalendarDays className="h-4 w-4" aria-hidden="true" />
+              Próximamente: agenda escolar integrada
             </div>
-          </CardBody>
-        </Card>
+          </div>
+        </header>
+
+        <section aria-labelledby="recent-section" className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 id="recent-section" className="text-lg font-semibold text-text">
+                Elementos recientes
+              </h2>
+              <p className="text-sm text-subtext">
+                Elegí un curso para ver sus anuncios destacados.
+              </p>
+            </div>
+            {cursoActual ? (
+              <span className="hidden rounded-full bg-surface px-3 py-1 text-xs text-subtext/80 sm:inline-flex">
+                Última actualización: {new Date(cursoActual.updatedAt || cursoActual.createdAt || Date.now()).toLocaleDateString("es-AR")}
+              </span>
+            ) : null}
+          </div>
+
+          {loadingCursos ? (
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+              {Array.from({ length: 4 }).map((_, index) => (
+                <RecentTile key={index} loading />
+              ))}
+            </div>
+          ) : cursos.length === 0 ? (
+            <div className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-muted/40 bg-surface/60 px-6 py-12 text-center text-subtext/80">
+              <BookOpen className="mb-4 h-10 w-10 text-subtext/50" aria-hidden="true" />
+              <p className="text-base font-medium text-text">Sin cursos todavía</p>
+              <p className="mt-1 text-sm text-subtext">
+                Cuando la institución te asigne cursos, aparecerán aquí con sus colores pastel.
+              </p>
+            </div>
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+              {cursos.map((curso, index) => {
+                const tone = tonePalette[index % tonePalette.length];
+                const subtitle = `${curso.anio}° ${curso.division || ""}`.trim();
+                return (
+                  <RecentTile
+                    key={curso._id}
+                    icon={BookOpen}
+                    title={curso.nombre}
+                    subtitle={subtitle}
+                    tone={tone}
+                    active={cursoSel === curso._id}
+                    onClick={() => setCursoSel(curso._id)}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </section>
+
+        <section aria-labelledby="announcements-section" className="space-y-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 id="announcements-section" className="text-lg font-semibold text-text">
+                Mis anuncios
+              </h2>
+              <p className="text-sm text-subtext">
+                Vista tipo parrilla para revisar tus notas y comunicados del curso seleccionado.
+              </p>
+            </div>
+            {cursoActual ? (
+              <div className="flex items-center gap-2 text-xs text-subtext/70">
+                <Megaphone className="h-4 w-4" aria-hidden="true" />
+                {cursoActual.nombre}
+              </div>
+            ) : null}
+          </div>
+
+          {loadingAnuncios ? (
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <AnnouncementCard key={index} loading />
+              ))}
+            </div>
+          ) : anuncios.length === 0 ? (
+            <div className="rounded-3xl border border-dashed border-muted/40 bg-gradient-to-br from-surface to-white px-6 py-16 text-center">
+              <Megaphone className="mx-auto mb-4 h-12 w-12 text-subtext/40" aria-hidden="true" />
+              <h3 className="text-base font-semibold text-text">Aún no hay anuncios para este curso</h3>
+              <p className="mt-2 text-sm text-subtext">
+                Publicá tu primer anuncio para mantener informadas a las familias y estudiantes.
+              </p>
+              {esCreador ? (
+                <Button className="mt-6" variant="subtle" onClick={() => setOpenNew(true)}>
+                  <Plus className="mr-2 h-4 w-4" aria-hidden="true" />
+                  Crear anuncio
+                </Button>
+              ) : null}
+            </div>
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              {anuncios.map((a, index) => {
+                const tone = tonePalette[index % tonePalette.length];
+                const fecha = new Date(a.createdAt).toLocaleDateString("es-AR", {
+                  day: "2-digit",
+                  month: "short",
+                });
+                const audienceLabel =
+                  !a.visiblePara || a.visiblePara === "todos"
+                    ? "Todos"
+                    : a.visiblePara.charAt(0).toUpperCase() + a.visiblePara.slice(1);
+                return (
+                  <AnnouncementCard
+                    key={a._id}
+                    title={a.titulo}
+                    summary={a.contenido}
+                    date={fecha}
+                    author={a.autor?.nombre}
+                    audience={audienceLabel}
+                    course={a.curso?.nombre}
+                    tone={tone}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </section>
       </div>
 
-      {/* Anuncios */}
-      <Card>
-        <CardHeader
-          title="Anuncios"
-          subtitle={cursoSel ? "Del curso seleccionado" : "Seleccioná un curso"}
-        />
-        <CardBody>
-          {anuncios.length === 0 ? (
-            <EmptyState title="Sin anuncios" desc="Cuando haya novedades, aparecerán aquí." />
-          ) : (
-            <ul className="space-y-3">
-              {anuncios.map((a) => (
-                <li key={a._id} className="p-4 rounded-2xl border border-muted bg-surface hover:bg-card transition">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2 text-subtext">
-                      <Megaphone className="h-4 w-4" aria-hidden="true" />
-                      <span>{a.curso?.nombre}</span>
-                      <span>•</span>
-                      <span>{new Date(a.createdAt).toLocaleString("es-AR")}</span>
-                    </div>
-                    <Badge color="brand">{a.autor?.rol}</Badge>
-                  </div>
-                  <div className="mt-1 text-lg font-semibold">{a.titulo}</div>
-                  <div className="text-sm text-text/90 whitespace-pre-line">{a.contenido}</div>
-                  <div className="text-xs text-subtext mt-1">
-                    Autor: {a.autor?.nombre}
-                    {a.visiblePara && a.visiblePara !== "todos" ? ` — visible para ${a.visiblePara}` : ""}
-                  </div>
-                </li>
-              ))}
-            </ul>
-          )}
-        </CardBody>
-      </Card>
-
-      {/* Modal Nuevo anuncio */}
       <Modal
         open={openNew}
         title="Publicar anuncio"
         onClose={() => setOpenNew(false)}
         actions={
           <>
-            <Button variant="ghost" onClick={() => setOpenNew(false)}>Cancelar</Button>
+            <Button variant="ghost" onClick={() => setOpenNew(false)}>
+              Cancelar
+            </Button>
             <Button onClick={crearAnuncio} disabled={saving}>
               {saving ? "Publicando…" : "Publicar"}
             </Button>
@@ -182,7 +267,10 @@ export default function Dashboard() {
         }
       >
         {cursos.length === 0 ? (
-          <div className="text-subtext">No hay cursos disponibles.</div>
+          <EmptyState
+            title="Sin cursos disponibles"
+            desc="Para publicar anuncios necesitás tener cursos asignados."
+          />
         ) : (
           <div className="space-y-3">
             <Select label="Curso" value={cursoSel} onChange={(e) => setCursoSel(e.target.value)}>
@@ -203,14 +291,18 @@ export default function Dashboard() {
             <label className="block">
               <div className="text-sm text-subtext mb-1">Contenido</div>
               <textarea
-                className="w-full min-h-[120px]"
+                className="w-full min-h-[120px] rounded-xl border border-muted bg-surface px-3 py-2"
                 value={contenido}
                 onChange={(e) => setContenido(e.target.value)}
                 placeholder="Detalles del anuncio…"
               />
             </label>
 
-            <Select label="Visible para" value={visiblePara} onChange={(e) => setVisiblePara(e.target.value)}>
+            <Select
+              label="Visible para"
+              value={visiblePara}
+              onChange={(e) => setVisiblePara(e.target.value)}
+            >
               <option value="todos">Todos</option>
               <option value="padres">Familias</option>
               <option value="estudiantes">Estudiantes</option>


### PR DESCRIPTION
## Summary
- reorganize the dashboard into recent course tiles and a grid-based "Mis anuncios" view
- extract reusable RecentTile and AnnouncementCard components with pastel styling, skeletons, and option affordances
- refresh call-to-action placement and empty/loading states to align with the updated UI shell

## Testing
- `npm run lint` *(fails: existing react-refresh lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e30c5c302c83248658c0c98af0c0d2