### PR TITLE
Refactor asistencia view with refreshed dashboard styling

### DIFF
--- a/frontend/src/components/ui/Button.jsx
+++ b/frontend/src/components/ui/Button.jsx
@@ -6,19 +6,34 @@ export default function Button({
   className = "",
   ...props
 }) {
+  const { disabled, ...rest } = props;
+
   const base =
-    "inline-flex items-center justify-center gap-2 px-4 py-2 rounded-xl " +
-    "font-semibold transition shadow-soft disabled:opacity-60 disabled:pointer-events-none";
+    "inline-flex items-center justify-center gap-2 px-4 py-2 rounded-2xl font-semibold " +
+    "transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-transparent " +
+    "shadow-soft disabled:opacity-60 disabled:pointer-events-none";
 
   const variants = {
-    primary: "bg-brand-500 text-black hover:bg-brand-600",
-    subtle: "bg-muted text-text hover:bg-card border border-muted",
-    ghost: "bg-transparent text-text hover:bg-muted border border-transparent",
-    danger: "bg-red-500 text-white hover:bg-red-600",
+    primary:
+      "bg-brand-500 text-slate-900 hover:bg-brand-400 focus:ring-brand-200",
+    secondary:
+      "bg-white/80 text-text border border-white/60 hover:bg-white focus:ring-brand-100",
+    soft:
+      "bg-brand-500/15 text-brand-400 hover:bg-brand-500/25 focus:ring-brand-200",
+    outline:
+      "bg-transparent text-brand-500 border border-brand-200 hover:bg-brand-500/10 focus:ring-brand-200",
+    ghost: "bg-transparent text-subtext hover:bg-muted/60 border border-transparent",
+    danger: "bg-red-500 text-white hover:bg-red-600 focus:ring-red-200",
+    success:
+      "bg-emerald-400 text-emerald-950 hover:bg-emerald-300 focus:ring-emerald-200",
   };
 
   return (
-    <button className={`${base} ${variants[variant]} ${className}`} {...props}>
+    <button
+      className={`${base} ${variants[variant] || variants.primary} ${className}`}
+      disabled={disabled || loading}
+      {...rest}
+    >
       {loading && (
         <span className="inline-block h-4 w-4 rounded-full border-2 border-black/30 border-t-black animate-spin" />
       )}

--- a/frontend/src/components/ui/Input.jsx
+++ b/frontend/src/components/ui/Input.jsx
@@ -1,10 +1,19 @@
 // frontend/src/components/ui/Input.jsx
-export default function Input({ label, helper, className="", ...props }) {
+export default function Input({
+  label,
+  helper,
+  className = "",
+  inputClassName = "",
+  ...props
+}) {
   return (
-    <label className={`block ${className}`}>
-      {label && <div className="text-sm text-subtext mb-1">{label}</div>}
-      <input {...props} className="w-full" />
-      {helper && <div className="mt-1 text-xs text-subtext">{helper}</div>}
+    <label className={`block space-y-1.5 ${className}`}>
+      {label && <div className="text-sm font-medium text-subtext/80">{label}</div>}
+      <input
+        {...props}
+        className={`w-full rounded-2xl border border-white/70 bg-white/95 px-4 py-2 text-sm text-text shadow-inner focus:outline-none focus:ring-2 focus:ring-brand-300 ${inputClassName}`}
+      />
+      {helper && <div className="text-xs text-subtext">{helper}</div>}
     </label>
   );
 }

--- a/frontend/src/components/ui/Modal.jsx
+++ b/frontend/src/components/ui/Modal.jsx
@@ -2,15 +2,20 @@
 export default function Modal({ open, title, onClose, actions, children }) {
   if (!open) return null;
   return (
-    <div className="fixed inset-0 z-[9998] bg-black/60 grid place-items-center p-4">
-      <div className="w-full max-w-lg bg-card rounded-2xl border border-muted shadow-soft">
-        <div className="p-4 border-b border-muted flex items-center justify-between">
-          <div className="font-semibold">{title}</div>
-          <button onClick={onClose} className="text-subtext hover:text-text">✕</button>
+    <div className="fixed inset-0 z-[9998] bg-slate-900/30 backdrop-blur-sm grid place-items-center p-4">
+      <div className="w-full max-w-xl rounded-3xl border border-white/60 bg-white/95 shadow-[0_20px_45px_-20px_rgba(15,23,42,0.45)]">
+        <div className="flex items-center justify-between gap-3 border-b border-white/60 bg-gradient-to-r from-white/80 to-white/40 p-5 rounded-t-3xl">
+          <div className="font-semibold text-text">{title}</div>
+          <button
+            onClick={onClose}
+            className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-black/5 text-subtext transition hover:bg-black/10 hover:text-text"
+          >
+            ✕
+          </button>
         </div>
-        <div className="p-4">{children}</div>
+        <div className="p-5 text-sm text-text">{children}</div>
         {actions && (
-          <div className="p-4 border-t border-muted flex justify-end gap-3">
+          <div className="flex justify-end gap-3 border-t border-white/60 bg-white/60 px-5 py-4 rounded-b-3xl">
             {actions}
           </div>
         )}

--- a/frontend/src/components/ui/Select.jsx
+++ b/frontend/src/components/ui/Select.jsx
@@ -1,10 +1,22 @@
 // frontend/src/components/ui/Select.jsx
-export default function Select({ label, helper, className="", children, ...props }) {
+export default function Select({
+  label,
+  helper,
+  className = "",
+  selectClassName = "",
+  children,
+  ...props
+}) {
   return (
-    <label className={`block ${className}`}>
-      {label && <div className="text-sm text-subtext mb-1">{label}</div>}
-      <select {...props} className="w-full">{children}</select>
-      {helper && <div className="mt-1 text-xs text-subtext">{helper}</div>}
+    <label className={`block space-y-1.5 ${className}`}>
+      {label && <div className="text-sm font-medium text-subtext/80">{label}</div>}
+      <select
+        {...props}
+        className={`w-full rounded-2xl border border-white/70 bg-white px-4 py-2 text-sm text-text shadow-inner focus:outline-none focus:ring-2 focus:ring-brand-300 ${selectClassName}`}
+      >
+        {children}
+      </select>
+      {helper && <div className="text-xs text-subtext">{helper}</div>}
     </label>
   );
 }

--- a/frontend/src/components/ui/Table.jsx
+++ b/frontend/src/components/ui/Table.jsx
@@ -1,16 +1,52 @@
 // frontend/src/components/ui/Table.jsx
-export function Table({ children }) {
-  return <div className="overflow-x-auto rounded-2xl border border-muted bg-card">{children}</div>;
+export function Table({ children, variant = "default", className = "" }) {
+  const variants = {
+    default: "border border-muted bg-card",
+    soft:
+      "border border-white/60 bg-white/70 backdrop-blur-sm shadow-inner ring-1 ring-black/5",
+  };
+
+  return (
+    <div className={`overflow-x-auto rounded-3xl ${variants[variant] || variants.default} ${className}`}>
+      {children}
+    </div>
+  );
 }
-export function THead({ children }) {
-  return <thead className="bg-surface text-subtext">{children}</thead>;
+
+export function THead({ children, className = "", ...props }) {
+  return (
+    <thead
+      className={`text-xs uppercase tracking-wide text-subtext/80 bg-white/60 ${className}`}
+      {...props}
+    >
+      {children}
+    </thead>
+  );
 }
-export function TRow({ children }) {
-  return <tr className="border-t border-muted">{children}</tr>;
+
+export function TRow({ children, className = "", ...props }) {
+  return (
+    <tr
+      className={`transition-colors border-t border-white/60 first:border-t-0 hover:bg-white/70 ${className}`}
+      {...props}
+    >
+      {children}
+    </tr>
+  );
 }
-export function TH({ children }) {
-  return <th className="p-3 text-left text-sm">{children}</th>;
+
+export function TH({ children, className = "", ...props }) {
+  return (
+    <th className={`p-4 text-left text-sm font-semibold ${className}`} {...props}>
+      {children}
+    </th>
+  );
 }
-export function TD({ children, className="" }) {
-  return <td className={`p-3 align-middle ${className}`}>{children}</td>;
+
+export function TD({ children, className = "", ...props }) {
+  return (
+    <td className={`p-4 align-middle text-sm ${className}`} {...props}>
+      {children}
+    </td>
+  );
 }


### PR DESCRIPTION
## Summary
- redesign the asistencia page with a new summary, filter panel, and pastel data table that match the refreshed dashboard aesthetic
- align button, input, select, table, and modal components with the updated variants and softer visual treatment used across the page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e30c5cc2e08324a36512ea0825b739