### PR TITLE
Adjust badge palette for improved contrast

### DIFF
--- a/frontend/src/components/ui/Badge.jsx
+++ b/frontend/src/components/ui/Badge.jsx
@@ -1,10 +1,10 @@
 export default function Badge({ children, color="brand" }) {
   const palette = {
-    brand: "bg-brand-500/15 text-brand-300 ring-1 ring-brand-500/20",
+    brand: "bg-brand-500/20 text-brand-700 ring-1 ring-brand-500/25",
     neutral: "bg-muted text-subtext ring-1 ring-black/10",
-    success: "bg-emerald-500/15 text-emerald-300 ring-1 ring-emerald-500/20",
-    warn: "bg-amber-500/15 text-amber-300 ring-1 ring-amber-500/20",
-    danger: "bg-red-500/15 text-red-300 ring-1 ring-red-500/20",
+    success: "bg-emerald-500/20 text-emerald-900 ring-1 ring-emerald-500/25",
+    warn: "bg-amber-500/20 text-amber-800 ring-1 ring-amber-500/25",
+    danger: "bg-red-500/20 text-red-800 ring-1 ring-red-500/25",
   };
   return (
     <span className={`px-2 py-1 rounded-lg text-xs ${palette[color]}`}>


### PR DESCRIPTION
## Summary
- darken badge text colors and slightly strengthen backgrounds to meet contrast requirements while preserving the soft green feel
- adjust badge outline opacities to harmonize with the updated palette

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3178b32bc8324ad3ec24dccde9126