### PR TITLE
Adjust dashboard course select styling

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -237,7 +237,8 @@ function HeroSummary({ user, cursos, cursoSel, onCursoChange, loading, onCreate 
                 <Select
                   value={cursoSel}
                   onChange={(e) => onCursoChange(e.target.value)}
-                  className="mt-3 w-full rounded-xl border border-muted/60 bg-white text-left text-sm text-text shadow-sm"
+                  className="mt-3 w-full"
+                  selectClassName="rounded-xl border border-muted/60 bg-white text-left text-sm text-text shadow-sm"
                 >
                   {cursos.map((c) => (
                     <option key={c._id} value={c._id}>


### PR DESCRIPTION
## Summary
- update the dashboard hero course selector to use the selectClassName prop
- move spacing utilities to the wrapper to keep the intended layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e31d54aefc8324af192708e815bbde