### PR TITLE
Adjust empty state text color for better contrast

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -272,7 +272,7 @@ function HeroSummary({ user, cursos, cursoSel, onCursoChange, loading, onCreate 
             </div>
           </div>
         ) : (
-          <div className="text-sm text-white/70">
+          <div className="text-sm text-subtext">
             Los anuncios nuevos aparecerán aquí cuando tus docentes los publiquen.
           </div>
         )}


### PR DESCRIPTION
## Summary
- update the empty announcements helper text to use the standard subtext color for accessibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e31d552e6c83249924114a6e7c9a20