### PR TITLE
Handle invalid user data when hydrating AuthProvider

### DIFF
--- a/frontend/src/context/AuthProvider.jsx
+++ b/frontend/src/context/AuthProvider.jsx
@@ -11,7 +11,14 @@ export default function AuthProvider({ children }) {
   useEffect(() => {
     // Hidratar desde localStorage
     const u = localStorage.getItem("user");
-    if (u) setUser(JSON.parse(u));
+    if (u) {
+      try {
+        setUser(JSON.parse(u));
+      } catch (error) {
+        console.warn("Failed to parse user from localStorage", error);
+        localStorage.removeItem("user");
+      }
+    }
     setLoading(false);
   }, []);
 


### PR DESCRIPTION
## Summary
- guard the AuthProvider hydration against invalid JSON stored under the user key
- drop the corrupt user value and emit a warning so initialization can proceed

## Testing
- Manual: not run (browser environment unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e3254b200883248238508a0800075d