### PR TITLE
fix: align router imports with react-router core

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router";
 import AuthProvider from "./context/AuthProvider";
 import PrivateRoute from "./components/PrivateRoute";
 import Login from "./pages/Login";

--- a/frontend/src/components/PrivateRoute.jsx
+++ b/frontend/src/components/PrivateRoute.jsx
@@ -1,4 +1,4 @@
-import { Navigate } from "react-router-dom";
+import { Navigate } from "react-router";
 import { useAuth } from "../context/AuthProvider";
 
 export default function PrivateRoute({ children }) {

--- a/frontend/src/components/Shell.jsx
+++ b/frontend/src/components/Shell.jsx
@@ -9,7 +9,7 @@ import {
   Settings,
   X,
 } from "lucide-react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router";
 import { useAuth } from "../context/AuthProvider";
 import { cloneElement, isValidElement, useMemo, useState } from "react";
 

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useAuth } from "../context/AuthProvider";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import Button from "../components/ui/Button";
 import { ShieldCheck, Mail, Lock } from "lucide-react";
 import { Card, CardBody } from "../components/ui/Card";


### PR DESCRIPTION
## Summary
- switch frontend router imports to use react-router core entry point
- ensure private route, shell, app, and login components reference the updated module

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e3254636e08324a1efc99b789b1f8b