### PR TITLE
Fix quick action icon rendering in Shell

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from "react-router";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import AuthProvider from "./context/AuthProvider";
 import PrivateRoute from "./components/PrivateRoute";
 import Login from "./pages/Login";

--- a/frontend/src/components/PrivateRoute.jsx
+++ b/frontend/src/components/PrivateRoute.jsx
@@ -1,4 +1,4 @@
-import { Navigate } from "react-router";
+import { Navigate } from "react-router-dom";
 import { useAuth } from "../context/AuthProvider";
 
 export default function PrivateRoute({ children }) {

--- a/frontend/src/components/Shell.jsx
+++ b/frontend/src/components/Shell.jsx
@@ -9,9 +9,15 @@ import {
   Settings,
   X,
 } from "lucide-react";
-import { Link, useLocation } from "react-router";
+import { Link, useLocation } from "react-router-dom";
 import { useAuth } from "../context/AuthProvider";
-import { cloneElement, isValidElement, useMemo, useState } from "react";
+import {
+  cloneElement,
+  createElement,
+  isValidElement,
+  useMemo,
+  useState,
+} from "react";
 
 export default function Shell({
   children,
@@ -249,6 +255,15 @@ export default function Shell({
                         iconContent = (
                           <IconComponent className="h-5 w-5" aria-hidden="true" />
                         );
+                      } else if (
+                        icon &&
+                        typeof icon === "object" &&
+                        ("render" in icon || "type" in icon || "$$typeof" in icon)
+                      ) {
+                        iconContent = createElement(icon, {
+                          className: "h-5 w-5",
+                          "aria-hidden": "true",
+                        });
                       } else {
                         iconContent = icon;
                       }

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useAuth } from "../context/AuthProvider";
-import { useNavigate } from "react-router";
+import { useNavigate } from "react-router-dom";
 import Button from "../components/ui/Button";
 import { ShieldCheck, Mail, Lock } from "lucide-react";
 import { Card, CardBody } from "../components/ui/Card";


### PR DESCRIPTION
## Summary
- handle forwardRef lucide icons in the Shell quick action buttons using createElement
- prevent the dashboard view from crashing to a blank screen after login by rendering the actions correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e32686ca988324b77c2cbb2044f059