### PR TITLE
feat: vista de estudiantes por curso

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import PrivateRoute from "./components/PrivateRoute";
 import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
 import Asistencia from "./pages/Asistencia";
+import Estudiantes from "./pages/Estudiantes";
 import NotFound from "./pages/NotFound";
 
 export default function App() {
@@ -19,6 +20,10 @@ export default function App() {
           <Route
             path="/asistencia"
             element={<PrivateRoute><Asistencia /></PrivateRoute>}
+          />
+          <Route
+            path="/estudiantes"
+            element={<PrivateRoute><Estudiantes /></PrivateRoute>}
           />
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/frontend/src/pages/Asistencia.jsx
+++ b/frontend/src/pages/Asistencia.jsx
@@ -46,6 +46,13 @@ export default function Asistencia() {
   const esDocenteOAdmin = user?.rol === "docente" || user?.rol === "admin";
   const esPadre = user?.rol === "padre";
   const esEstudiante = user?.rol === "estudiante";
+  const tabs = [
+    { to: "/", label: "Inicio" },
+    { to: "/asistencia", label: "Asistencia" },
+  ];
+  if (esDocenteOAdmin) {
+    tabs.push({ to: "/estudiantes", label: "Estudiantes" });
+  }
 
   // Cargar cursos para docente/admin
   useEffect(() => {
@@ -213,10 +220,7 @@ export default function Asistencia() {
 
   return (
     <Shell
-      tabs={[
-        { to: "/", label: "Inicio" },
-        { to: "/asistencia", label: "Asistencia" },
-      ]}
+      tabs={tabs}
     >
       <div className="space-y-8">
         <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -30,6 +30,13 @@ export default function Dashboard() {
   const [saving, setSaving] = useState(false);
 
   const esCreador = user?.rol === "admin" || user?.rol === "docente";
+  const tabs = [
+    { to: "/", label: "Inicio" },
+    { to: "/asistencia", label: "Asistencia" },
+  ];
+  if (esCreador) {
+    tabs.push({ to: "/estudiantes", label: "Estudiantes" });
+  }
 
   // Cargar cursos
   useEffect(() => {
@@ -89,10 +96,7 @@ export default function Dashboard() {
 
   return (
     <Shell
-      tabs={[
-        { to: "/", label: "Inicio" },
-        { to: "/asistencia", label: "Asistencia" },
-      ]}
+      tabs={tabs}
       title="Panel principal"
       description={
         cursoActual

--- a/frontend/src/pages/Estudiantes.jsx
+++ b/frontend/src/pages/Estudiantes.jsx
@@ -1,0 +1,256 @@
+// frontend/src/pages/Estudiantes.jsx
+import { useEffect, useMemo, useState } from "react";
+import Shell from "../components/Shell";
+import { useAuth } from "../context/AuthProvider";
+import { apiGet } from "../api";
+import Select from "../components/ui/Select";
+import Badge from "../components/ui/Badge";
+import { Card, CardHeader, CardBody } from "../components/ui/Card";
+import { Table, THead, TRow, TH, TD } from "../components/ui/Table";
+import EmptyState from "../components/ui/EmptyState";
+import Skeleton from "../components/ui/Skeleton";
+
+const TURNO_TODOS = "todos";
+const DIVISION_TODAS = "todas";
+
+function resolveTurno(curso) {
+  return curso?.turno?.trim() || "Sin turno";
+}
+
+function resolveDivision(curso) {
+  return curso?.division?.trim() || "Sin división";
+}
+
+export default function Estudiantes() {
+  const { user } = useAuth();
+  const [cursos, setCursos] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [turno, setTurno] = useState(TURNO_TODOS);
+  const [division, setDivision] = useState(DIVISION_TODAS);
+
+  const autorizado = user?.rol === "admin" || user?.rol === "docente";
+
+  useEffect(() => {
+    if (!autorizado) {
+      setCursos([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    (async () => {
+      try {
+        const data = await apiGet("/api/cursos");
+        setCursos(Array.isArray(data) ? data : []);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [autorizado]);
+
+  const tabs = useMemo(() => {
+    const base = [
+      { to: "/", label: "Inicio" },
+      { to: "/asistencia", label: "Asistencia" },
+    ];
+    if (autorizado) {
+      base.push({ to: "/estudiantes", label: "Estudiantes" });
+    }
+    return base;
+  }, [autorizado]);
+
+  const turnos = useMemo(() => {
+    const collator = new Intl.Collator("es", { sensitivity: "base" });
+    const set = new Set();
+    cursos.forEach((curso) => {
+      set.add(resolveTurno(curso));
+    });
+    return Array.from(set).sort(collator.compare);
+  }, [cursos]);
+
+  const divisiones = useMemo(() => {
+    const collator = new Intl.Collator("es", { sensitivity: "base" });
+    const set = new Set();
+    cursos.forEach((curso) => {
+      if (turno !== TURNO_TODOS && resolveTurno(curso) !== turno) return;
+      set.add(resolveDivision(curso));
+    });
+    return Array.from(set).sort(collator.compare);
+  }, [cursos, turno]);
+
+  useEffect(() => {
+    if (turno !== TURNO_TODOS && !turnos.includes(turno)) {
+      setTurno(TURNO_TODOS);
+    }
+  }, [turno, turnos]);
+
+  useEffect(() => {
+    if (division !== DIVISION_TODAS && !divisiones.includes(division)) {
+      setDivision(DIVISION_TODAS);
+    }
+  }, [division, divisiones]);
+
+  const cursosFiltrados = useMemo(() => {
+    return cursos.filter((curso) => {
+      const turnoCurso = resolveTurno(curso);
+      const divisionCurso = resolveDivision(curso);
+
+      const coincideTurno = turno === TURNO_TODOS || turnoCurso === turno;
+      const coincideDivision =
+        division === DIVISION_TODAS || divisionCurso === division;
+
+      return coincideTurno && coincideDivision;
+    });
+  }, [cursos, turno, division]);
+
+  const descripcion = autorizado
+    ? "Visualizá el padrón de estudiantes y docentes asignados por curso."
+    : "Acceso exclusivo para personal docente y administrativo.";
+
+  if (!autorizado) {
+    return (
+      <Shell tabs={tabs} title="Estudiantes" description={descripcion}>
+        <EmptyState
+          title="Acceso restringido"
+          desc="No contás con permisos para ver la nómina de estudiantes."
+        />
+      </Shell>
+    );
+  }
+
+  return (
+    <Shell tabs={tabs} title="Estudiantes" description={descripcion}>
+      <section className="space-y-6">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <Select
+            label="Turno"
+            value={turno}
+            onChange={(event) => setTurno(event.target.value)}
+          >
+            <option value={TURNO_TODOS}>Todos los turnos</option>
+            {turnos.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </Select>
+
+          <Select
+            label="División"
+            value={division}
+            onChange={(event) => setDivision(event.target.value)}
+          >
+            <option value={DIVISION_TODAS}>Todas las divisiones</option>
+            {divisiones.map((d) => (
+              <option key={d} value={d}>
+                {d}
+              </option>
+            ))}
+          </Select>
+        </div>
+
+        {loading ? (
+          <div className="space-y-4">
+            {[0, 1, 2].map((i) => (
+              <Skeleton key={i} className="h-40 w-full" />
+            ))}
+          </div>
+        ) : cursosFiltrados.length === 0 ? (
+          <EmptyState
+            title="Sin cursos"
+            desc="No se encontraron cursos que coincidan con los filtros seleccionados."
+          />
+        ) : (
+          <div className="space-y-6">
+            {cursosFiltrados.map((curso) => {
+              const personas = [
+                ...(Array.isArray(curso.docentes)
+                  ? curso.docentes.map((persona) => ({
+                      tipo: "docente",
+                      persona,
+                    }))
+                  : []),
+                ...(Array.isArray(curso.alumnos)
+                  ? curso.alumnos.map((persona) => ({
+                      tipo: "estudiante",
+                      persona,
+                    }))
+                  : []),
+              ];
+
+              const turnoCurso = resolveTurno(curso);
+              const divisionCurso = resolveDivision(curso);
+
+              return (
+                <Card key={curso._id || `${curso.anio}-${curso.nombre}`}> 
+                  <CardHeader
+                    title={
+                      curso.nombre
+                        ? `${curso.nombre}`
+                        : `Curso ${curso.anio || ""}`
+                    }
+                    subtitle={`${curso.anio || ""}° · ${divisionCurso}`}
+                    actions={<Badge color="neutral">{turnoCurso}</Badge>}
+                  />
+                  <CardBody className="space-y-4">
+                    <div className="flex flex-wrap items-center gap-2 text-sm text-subtext">
+                      <span className="font-semibold text-text">Docentes:</span>
+                      {Array.isArray(curso.docentes) && curso.docentes.length > 0 ? (
+                        curso.docentes.map((docente) => (
+                          <Badge key={docente._id || docente.email} color="warn">
+                            {docente.nombre || docente.email}
+                          </Badge>
+                        ))
+                      ) : (
+                        <Badge color="neutral">Sin docentes asignados</Badge>
+                      )}
+                    </div>
+
+                    <Table variant="soft">
+                      <table className="min-w-full text-left">
+                        <THead>
+                          <TRow className="bg-transparent">
+                            <TH>Nombre</TH>
+                            <TH>Email</TH>
+                            <TH className="w-32">Rol</TH>
+                          </TRow>
+                        </THead>
+                        <tbody>
+                          {personas.length === 0 ? (
+                            <TRow>
+                              <TD colSpan={3} className="text-center text-subtext">
+                                No hay integrantes asignados.
+                              </TD>
+                            </TRow>
+                          ) : (
+                            personas.map(({ persona, tipo }) => (
+                              <TRow key={`${curso._id || curso.nombre}-${tipo}-${persona._id || persona.email}`}>
+                                <TD>
+                                  <div className="font-medium text-text">
+                                    {persona.nombre || "Sin nombre"}
+                                  </div>
+                                </TD>
+                                <TD className="text-subtext">
+                                  {persona.email || "Sin correo"}
+                                </TD>
+                                <TD>
+                                  <Badge color={tipo === "docente" ? "warn" : "brand"}>
+                                    {tipo === "docente" ? "Docente" : "Estudiante"}
+                                  </Badge>
+                                </TD>
+                              </TRow>
+                            ))
+                          )}
+                        </tbody>
+                      </table>
+                    </Table>
+                  </CardBody>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </section>
+    </Shell>
+  );
+}


### PR DESCRIPTION
## Summary
- agrega la ruta protegida `/estudiantes` y el componente Estudiantes para mostrar los cursos
- reutiliza `/api/cursos` para listar docentes y alumnos con filtros por turno y división
- expone la nueva sección en las tabs del panel para roles docentes o administradores

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3fbd8e0dc8324b527a9d235dd5c36