### PR TITLE
Add cursos seed script

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,41 @@
+# Backend
+
+## Seed de cursos
+
+El script `seedCursos` genera (o actualiza, si ya existen) los cursos base del sistema
+combinando:
+
+- Años: 1 a 5
+- Divisiones: `1` y `2`
+- Turnos: `TM` y `TT`
+
+El proceso es **idempotente** gracias al uso de `Curso.updateOne(..., { upsert: true })`,
+por lo que puede ejecutarse múltiples veces sin crear duplicados.
+
+### Variables de entorno necesarias
+
+Antes de ejecutar el seed asegurate de contar con un archivo `.env` (en la raíz del
+backend) con al menos la siguiente variable:
+
+```bash
+MONGO_URI=mongodb://usuario:password@host:puerto/base
+```
+
+> `MONGO_URI` debe apuntar a la base de datos donde se crearán/actualizarán los cursos.
+
+### Ejecución
+
+Instala las dependencias del backend si aún no lo hiciste:
+
+```bash
+npm install
+```
+
+Luego ejecutá el seed:
+
+```bash
+npm run seed:cursos
+```
+
+El comando mostrará en consola cuántos cursos fueron creados, actualizados o estaban ya
+sin cambios.

--- a/backend/models/Curso.js
+++ b/backend/models/Curso.js
@@ -5,6 +5,7 @@ const cursoSchema = new mongoose.Schema(
     nombre: { type: String, required: true },
     anio: { type: Number, required: true }, // ej. 1, 2, 3
     division: { type: String }, // ej. "A", "B"
+    turno: { type: String, enum: ["TM", "TT"] }, // ej. "TM", "TT"
     docentes: [{ type: mongoose.Schema.Types.ObjectId, ref: "User" }],
     alumnos: [{ type: mongoose.Schema.Types.ObjectId, ref: "User" }]
   },

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "nodemon index.js",
-    "start": "node index.js"
+    "start": "node index.js",
+    "seed:cursos": "node ./scripts/seedCursos.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/backend/scripts/seedCursos.js
+++ b/backend/scripts/seedCursos.js
@@ -1,0 +1,81 @@
+import dotenv from "dotenv";
+import mongoose from "mongoose";
+
+import Curso from "../models/Curso.js";
+
+dotenv.config();
+
+const { MONGO_URI } = process.env;
+
+if (!MONGO_URI) {
+  console.error("❌ Falta la variable de entorno MONGO_URI");
+  process.exit(1);
+}
+
+const anios = [1, 2, 3, 4, 5];
+const divisiones = ["1", "2"];
+const turnos = ["TM", "TT"];
+
+const summary = {
+  created: 0,
+  updated: 0,
+  unchanged: 0
+};
+
+const createdOrUpdated = [];
+
+async function run() {
+  try {
+    await mongoose.connect(MONGO_URI);
+    console.log("✅ Conectado a MongoDB");
+
+    for (const anio of anios) {
+      for (const division of divisiones) {
+        for (const turno of turnos) {
+          const nombre = `${anio}° ${division} ${turno}`;
+          const filter = { anio, division, turno };
+          const update = {
+            $set: {
+              nombre,
+              anio,
+              division,
+              turno
+            }
+          };
+
+          const result = await Curso.updateOne(filter, update, { upsert: true });
+
+          if (result.upsertedCount && result.upsertedCount > 0) {
+            summary.created += 1;
+            createdOrUpdated.push({ nombre, accion: "creado" });
+          } else if (result.modifiedCount && result.modifiedCount > 0) {
+            summary.updated += 1;
+            createdOrUpdated.push({ nombre, accion: "actualizado" });
+          } else {
+            summary.unchanged += 1;
+          }
+        }
+      }
+    }
+
+    console.log("Resumen del seed de cursos:");
+    if (createdOrUpdated.length > 0) {
+      console.table(createdOrUpdated);
+    } else {
+      console.log("No hubo cursos nuevos ni actualizados; todo estaba al día.");
+    }
+
+    console.log(
+      `Total combinaciones: ${anios.length * divisiones.length * turnos.length}. ` +
+        `Creados: ${summary.created}, Actualizados: ${summary.updated}, Sin cambios: ${summary.unchanged}`
+    );
+  } catch (error) {
+    console.error("❌ Error ejecutando el seed de cursos:", error);
+    process.exitCode = 1;
+  } finally {
+    await mongoose.disconnect();
+    console.log("🔌 Conexión a MongoDB cerrada");
+  }
+}
+
+run();


### PR DESCRIPTION
## Summary
- add a reusable seed script that upserts all curso combinations for años 1–5, divisiones 1–2 y turnos TM/TT
- extend the Curso schema with the turno field used by the seed and expose an npm script to run it
- document how to execute the seed and required environment variables in the backend README

## Testing
- not run (requires database access)


------
https://chatgpt.com/codex/tasks/task_e_68e3fbd219d88324bc0598f28c5e8127