### PR TITLE
Add course shift support across backend and UI

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -3,6 +3,7 @@ import express from "express";
 import cors from "cors";
 import dotenv from "dotenv";
 import mongoose from "mongoose";
+import Curso from "./models/Curso.js";
 
 // 1) Cargar .env primero
 dotenv.config();
@@ -16,7 +17,20 @@ app.use(express.json());
 const { MONGO_URI, PORT } = process.env;
 mongoose
   .connect(MONGO_URI)
-  .then(() => console.log("✅ Conectado a MongoDB"))
+  .then(async () => {
+    console.log("✅ Conectado a MongoDB");
+    try {
+      const { modifiedCount } = await Curso.updateMany(
+        { $or: [{ turno: { $exists: false } }, { turno: null }] },
+        { $set: { turno: "TM" } }
+      );
+      if (modifiedCount > 0) {
+        console.log(`ℹ️ Cursos actualizados con turno predeterminado: ${modifiedCount}`);
+      }
+    } catch (err) {
+      console.error("❌ Error al migrar turnos de cursos:", err.message);
+    }
+  })
   .catch((err) => console.error("❌ Error MongoDB:", err.message));
 import path from "path";
 import multer from "multer";

--- a/backend/models/Curso.js
+++ b/backend/models/Curso.js
@@ -5,6 +5,7 @@ const cursoSchema = new mongoose.Schema(
     nombre: { type: String, required: true },
     anio: { type: Number, required: true }, // ej. 1, 2, 3
     division: { type: String }, // ej. "A", "B"
+    turno: { type: String, enum: ["TM", "TT"], required: true },
     docentes: [{ type: mongoose.Schema.Types.ObjectId, ref: "User" }],
     alumnos: [{ type: mongoose.Schema.Types.ObjectId, ref: "User" }]
   },

--- a/backend/routes/cursos.js
+++ b/backend/routes/cursos.js
@@ -7,6 +7,16 @@ const router = Router();
 // Crear un curso (solo admin)
 router.post("/", requireAuth, requireRole("admin"), async (req, res) => {
   try {
+    const { turno } = req.body;
+
+    if (!turno) {
+      return res.status(400).json({ error: "El turno es obligatorio" });
+    }
+
+    if (!["TM", "TT"].includes(turno)) {
+      return res.status(400).json({ error: "Turno inválido. Debe ser TM o TT" });
+    }
+
     const curso = await Curso.create(req.body);
     res.status(201).json(curso);
   } catch (err) {

--- a/frontend/src/pages/Asistencia.jsx
+++ b/frontend/src/pages/Asistencia.jsx
@@ -14,6 +14,12 @@ import { Table, THead, TRow, TH, TD } from "../components/ui/Table";
 import EmptyState from "../components/ui/EmptyState";
 import Skeleton from "../components/ui/Skeleton";
 
+const formatCursoEtiqueta = (curso) => {
+  if (!curso) return "";
+  const partes = [`${curso.anio}°`, curso.division, curso.turno].filter(Boolean);
+  return partes.join(" ");
+};
+
 function hoyStr(d = new Date()) {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");
@@ -277,7 +283,7 @@ export default function Asistencia() {
                     <Select value={cursoSel} onChange={(e) => setCursoSel(e.target.value)}>
                       {cursos.map((c) => (
                         <option key={c._id} value={c._id}>
-                          {c.nombre} — {c.anio}° {c.division || ""}
+                          {c.nombre} — {formatCursoEtiqueta(c)}
                         </option>
                       ))}
                     </Select>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -13,6 +13,12 @@ import Select from "../components/ui/Select";
 import EmptyState from "../components/ui/EmptyState";
 import Input from "../components/ui/Input";
 
+const formatCursoEtiqueta = (curso) => {
+  if (!curso) return "";
+  const partes = [`${curso.anio}°`, curso.division, curso.turno].filter(Boolean);
+  return partes.join(" ");
+};
+
 export default function Dashboard() {
   const { user } = useAuth();
   const toast = useToast();
@@ -96,7 +102,7 @@ export default function Dashboard() {
       title="Panel principal"
       description={
         cursoActual
-          ? `Curso seleccionado: ${cursoActual.nombre} — ${cursoActual.anio}° ${cursoActual.division || ""}`
+          ? `Curso seleccionado: ${cursoActual.nombre} — ${formatCursoEtiqueta(cursoActual)}`
           : "Resumen general de novedades y cursos"
       }
       addNewLabel="Nuevo anuncio"
@@ -137,7 +143,10 @@ export default function Dashboard() {
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2 text-subtext">
                       <Megaphone className="h-4 w-4" aria-hidden="true" />
-                      <span>{a.curso?.nombre}</span>
+                      <span>
+                        {a.curso?.nombre}
+                        {a.curso ? ` — ${formatCursoEtiqueta(a.curso)}` : ""}
+                      </span>
                       <span>•</span>
                       <span>{new Date(a.createdAt).toLocaleString("es-AR")}</span>
                     </div>
@@ -177,7 +186,7 @@ export default function Dashboard() {
             <Select label="Curso" value={cursoSel} onChange={(e) => setCursoSel(e.target.value)}>
               {cursos.map((c) => (
                 <option key={c._id} value={c._id}>
-                  {c.nombre} — {c.anio}° {c.division || ""}
+                  {c.nombre} — {formatCursoEtiqueta(c)}
                 </option>
               ))}
             </Select>
@@ -242,7 +251,7 @@ function HeroSummary({ user, cursos, cursoSel, onCursoChange, loading, onCreate 
                 >
                   {cursos.map((c) => (
                     <option key={c._id} value={c._id}>
-                      {c.nombre} — {c.anio}° {c.division || ""}
+                      {c.nombre} — {formatCursoEtiqueta(c)}
                     </option>
                   ))}
                 </Select>


### PR DESCRIPTION
## Summary
- add the `turno` field to cursos, backfill missing records on startup, and validate it on creation
- surface the turno information alongside course labels across the dashboard and asistencia views

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3fbc9487c83248e08f8857a916fd0