### PR TITLE
Expose users API router

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,15 @@
+# Backend API
+
+## Endpoints
+
+### `POST /api/auth/login`
+_Documentation pending._
+
+### `POST /api/auth/register`
+_Documentation pending._
+
+### `GET /api/cursos`
+_Documentation pending._
+
+### `GET /api/users`
+Obtiene el listado de usuarios registrados, incluyendo la información necesaria para vincular familiares y estudiantes. Utiliza los parámetros de consulta `tipo`, `familiaId` o `estudianteId` para filtrar los resultados según el caso de uso del equipo.

--- a/backend/index.js
+++ b/backend/index.js
@@ -53,6 +53,8 @@ import authRouter from "./routes/auth.js";
 app.use("/api/auth", authRouter);
 import cursosRouter from "./routes/cursos.js";
 app.use("/api/cursos", cursosRouter);
+import usersRouter from "./routes/users.js";
+
 
 // 6) Middlewares de auth/rol y rutas protegidas (DESPUÉS de tener app)
 import { requireAuth, requireRole } from "./middleware/auth.js";
@@ -68,6 +70,7 @@ import anunciosRouter from "./routes/anuncios.js";
 app.use("/api/anuncios", anunciosRouter);
 import asistRouter from "./routes/asistencias.js";
 app.use("/api/asistencias", asistRouter);
+app.use("/api/users", usersRouter);
 
 // 7) Levantar servidor al final
 app.listen(PORT || 5000, () => {


### PR DESCRIPTION
## Summary
- import and register the users router so the `/api/users` endpoints are available through Express
- document the `/api/users` endpoint in the backend README to guide the team on linking familiares y estudiantes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3fbc35e008324ac81609997b2bb8c