### PR TITLE
Include turno field in anuncios curso population

### DIFF
--- a/backend/routes/anuncios.js
+++ b/backend/routes/anuncios.js
@@ -41,7 +41,7 @@ router.get("/", requireAuth, async (req, res) => {
     const anuncios = await Anuncio.find(filtro)
       .sort({ createdAt: -1 })
       .populate("autor", "nombre rol")
-      .populate("curso", "nombre anio division");
+      .populate("curso", "nombre anio division turno");
 
     res.json(anuncios);
   } catch (e) {


### PR DESCRIPTION
## Summary
- include the turno field when populating curso documents in the anuncios route to expose the full course label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e400665124832488d4082eb6700cdc