### PR TITLE
Allow anuncios to be visible for docentes

### DIFF
--- a/backend/models/anuncio.js
+++ b/backend/models/anuncio.js
@@ -6,7 +6,11 @@ const anuncioSchema = new mongoose.Schema(
     contenido: { type: String, required: true },
     curso: { type: mongoose.Schema.Types.ObjectId, ref: "Curso", required: true },
     autor: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
-    visiblePara: { type: String, enum: ["todos", "padres", "estudiantes"], default: "todos" }
+    visiblePara: {
+      type: String,
+      enum: ["todos", "padres", "estudiantes", "docentes"],
+      default: "todos",
+    }
     // más adelante podemos sumar: fechaHasta, archivos, etiquetas, etc.
   },
   { timestamps: true }

--- a/backend/routes/anuncios.js
+++ b/backend/routes/anuncios.js
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { requireAuth, requireRole } from "../middleware/auth.js";
-import Anuncio from "../models/Anuncio.js";
+import Anuncio from "../models/anuncio.js";
 
 const router = Router();
 


### PR DESCRIPTION
## Summary
- allow the `Anuncio` schema to accept `docentes` in the `visiblePara` enum
- fix the anuncios router import to match the filename casing on case-sensitive filesystems

## Testing
- ⚠️ `node node_modules/nodemon/bin/nodemon.js index.js` *(fails to connect to MongoDB: ECONNREFUSED in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e403d04220832494ccf8a98e3e034b