### PR TITLE
Add users router to backend entry point

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -53,6 +53,7 @@ import authRouter from "./routes/auth.js";
 app.use("/api/auth", authRouter);
 import cursosRouter from "./routes/cursos.js";
 app.use("/api/cursos", cursosRouter);
+import usersRouter from "./routes/users.js";
 
 // 6) Middlewares de auth/rol y rutas protegidas (DESPUÉS de tener app)
 import { requireAuth, requireRole } from "./middleware/auth.js";
@@ -68,6 +69,7 @@ import anunciosRouter from "./routes/anuncios.js";
 app.use("/api/anuncios", anunciosRouter);
 import asistRouter from "./routes/asistencias.js";
 app.use("/api/asistencias", asistRouter);
+app.use("/api/users", usersRouter);
 
 // 7) Levantar servidor al final
 app.listen(PORT || 5000, () => {


### PR DESCRIPTION
## Summary
- import the users router into the backend entry point alongside other route modules
- register the users router under /api/users to expose the agregar-hijo endpoint

## Testing
- curl -X PUT http://localhost:5000/api/users/123/agregar-hijo -H 'Content-Type: application/json' -d '{"hijoId":"456"}'

------
https://chatgpt.com/codex/tasks/task_e_68e40a8ede1483248e94938a3ee45339