### PR TITLE
Refactor upload config to use shared middleware

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -3,6 +3,7 @@ import express from "express";
 import cors from "cors";
 import dotenv from "dotenv";
 import mongoose from "mongoose";
+import { UPLOAD_DIR } from "./middleware/upload.js";
 
 // 1) Cargar .env primero
 dotenv.config();
@@ -28,30 +29,8 @@ mongoose
   .connect(MONGO_URI)
   .then(() => console.log("✅ Conectado a MongoDB"))
   .catch((err) => console.error("❌ Error MongoDB:", err.message));
-import path from "path";
-import multer from "multer";
-
-// Servir /uploads como estático
-app.use("/uploads", express.static("uploads"));
-
-// Configurar Multer (archivos: PDF/JPG/PNG hasta 5 MB)
-const storage = multer.diskStorage({
-  destination: (_req, _file, cb) => cb(null, "uploads"),
-  filename: (_req, file, cb) => {
-    // yyyy-mm-dd_hhmmss-original.ext
-    const ts = new Date().toISOString().replace(/[:.]/g, "-");
-    const safe = file.originalname.replace(/\s+/g, "_");
-    cb(null, `${ts}-${safe}`);
-  }
-});
-export const upload = multer({
-  storage,
-  limits: { fileSize: 5 * 1024 * 1024 },
-  fileFilter: (_req, file, cb) => {
-    const ok = ["application/pdf", "image/jpeg", "image/png"].includes(file.mimetype);
-    cb(ok ? null : new Error("Tipo de archivo no permitido (solo PDF/JPG/PNG)"));
-  }
-});
+// Servir /uploads como estático reutilizando la misma configuración centralizada
+app.use("/uploads", express.static(UPLOAD_DIR));
 
 // 4) Rutas simples de vida
 app.get("/", (_req, res) => {

--- a/backend/middleware/upload.js
+++ b/backend/middleware/upload.js
@@ -1,7 +1,7 @@
 import multer from "multer";
 import fs from "fs";
 
-const UPLOAD_DIR = "uploads";
+export const UPLOAD_DIR = "uploads";
 if (!fs.existsSync(UPLOAD_DIR)) fs.mkdirSync(UPLOAD_DIR);
 
 const storage = multer.diskStorage({


### PR DESCRIPTION
## Summary
- reuse the shared upload middleware from the main server bootstrap instead of redefining multer
- export the upload directory constant so static serving and middleware stay in sync

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e46681f31883248135a1d0372f9274