### PR TITLE
Add attendance summary metrics and dashboard integration

### DIFF
--- a/backend/routes/asistencias.js
+++ b/backend/routes/asistencias.js
@@ -6,6 +6,45 @@ import { upload } from "../middleware/upload.js";
 
 const router = Router();
 
+function todayStr(date = new Date()) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+async function buildMatchFilter(req, { curso, fecha, alumno, desde, hasta }) {
+  const match = {};
+
+  if (curso) match.curso = curso;
+  if (fecha) match.fecha = fecha;
+  if (alumno) match.alumno = alumno;
+
+  if (desde || hasta) {
+    match.fecha = match.fecha || {};
+    if (desde) match.fecha.$gte = desde;
+    if (hasta) match.fecha.$lte = hasta;
+  }
+
+  if (req.user.rol === "padre") {
+    const padre = await User.findById(req.user.uid);
+    const hijos = (padre?.hijos || []).map(String);
+    if (match.alumno) {
+      if (!hijos.includes(String(match.alumno))) {
+        throw Object.assign(new Error("No autorizado para ver a este alumno"), { status: 403 });
+      }
+    } else {
+      match.alumno = { $in: hijos };
+    }
+  }
+
+  if (req.user.rol === "estudiante") {
+    match.alumno = req.user.uid;
+  }
+
+  return match;
+}
+
 /**
  * POST /api/asistencias/marcar
  * (docente o admin) Carga en bloque para un curso y fecha.
@@ -33,40 +72,150 @@ router.post("/marcar", requireAuth, requireRole("docente","admin"), async (req, 
 });
 
 /**
+ * GET /api/asistencias/resumen
+ * Devuelve totales y porcentajes por estado, tardanzas y pendientes.
+ * Query: curso, desde, hasta, ultimosDias
+ */
+router.get("/resumen", requireAuth, async (req, res) => {
+  try {
+    const { curso, desde, hasta, ultimosDias } = req.query;
+
+    let range = { desde, hasta };
+    if (!desde && ultimosDias) {
+      const days = Math.max(parseInt(ultimosDias, 10) || 0, 0);
+      if (days > 0) {
+        const start = new Date();
+        start.setDate(start.getDate() - (days - 1));
+        range.desde = todayStr(start);
+      }
+    }
+
+    const match = await buildMatchFilter(req, {
+      curso,
+      desde: range.desde,
+      hasta: range.hasta,
+    });
+
+    const [counts, pending, timeline] = await Promise.all([
+      Asistencia.aggregate([
+        { $match: match },
+        {
+          $group: {
+            _id: "$estado",
+            total: { $sum: 1 },
+          },
+        },
+      ]),
+      Asistencia.aggregate([
+        {
+          $match: {
+            ...match,
+            "justificacion.archivoUrl": { $exists: true, $ne: null },
+            "justificacion.aprobado": false,
+          },
+        },
+        { $count: "total" },
+      ]),
+      Asistencia.aggregate([
+        { $match: match },
+        {
+          $group: {
+            _id: "$fecha",
+            total: { $sum: 1 },
+            presentes: {
+              $sum: {
+                $cond: [{ $eq: ["$estado", "presente"] }, 1, 0],
+              },
+            },
+            ausentes: {
+              $sum: {
+                $cond: [{ $eq: ["$estado", "ausente"] }, 1, 0],
+              },
+            },
+            tardes: {
+              $sum: {
+                $cond: [{ $eq: ["$estado", "tarde"] }, 1, 0],
+              },
+            },
+            justificados: {
+              $sum: {
+                $cond: [{ $eq: ["$estado", "justificado"] }, 1, 0],
+              },
+            },
+          },
+        },
+        { $sort: { _id: 1 } },
+      ]),
+    ]);
+
+    const totals = counts.reduce(
+      (acc, curr) => {
+        acc.total += curr.total;
+        acc.byEstado[curr._id] = curr.total;
+        return acc;
+      },
+      { total: 0, byEstado: {} }
+    );
+
+    const estados = ["presente", "ausente", "tarde", "justificado"]; // mantener orden
+    const estadosDetalle = estados.reduce((acc, estado) => {
+      const totalEstado = totals.byEstado[estado] || 0;
+      const porcentaje = totals.total ? Math.round((totalEstado / totals.total) * 100) : 0;
+      acc[estado] = { total: totalEstado, porcentaje };
+      return acc;
+    }, {});
+
+    const timelineParsed = timeline.map((item) => {
+      const { _id: fechaItem, total, presentes, ausentes, tardes, justificados } = item;
+      return {
+        fecha: fechaItem,
+        total,
+        presentes,
+        ausentes,
+        tardes,
+        justificados,
+        porcentajePresente: total ? Math.round((presentes / total) * 100) : 0,
+      };
+    });
+
+    res.json({
+      total: totals.total,
+      estados: estadosDetalle,
+      llegadasTarde: {
+        total: estadosDetalle.tarde.total,
+        porcentaje: estadosDetalle.tarde.porcentaje,
+      },
+      justificacionesPendientes: pending[0]?.total || 0,
+      timeline: timelineParsed,
+      periodo: {
+        desde: range.desde || null,
+        hasta: range.hasta || null,
+      },
+    });
+  } catch (error) {
+    const status = error.status || 500;
+    res.status(status).json({ error: error.message || "Error al obtener resumen" });
+  }
+});
+
+/**
  * GET /api/asistencias?curso=<id>&fecha=YYYY-MM-DD&alumno=<id>
  * Listado por curso/fecha (docente/admin) o por alumno (padre/estudiante con restricción).
  */
 router.get("/", requireAuth, async (req, res) => {
-  const { curso, fecha, alumno } = req.query;
-  const filtro = {};
+  try {
+    const { curso, fecha, alumno } = req.query;
+    const filtro = await buildMatchFilter(req, { curso, fecha, alumno });
 
-  if (curso) filtro.curso = curso;
-  if (fecha) filtro.fecha = fecha;
-  if (alumno) filtro.alumno = alumno;
-
-  // Restricción por rol:
-  if (req.user.rol === "padre") {
-    const padre = await User.findById(req.user.uid);
-    const hijos = (padre?.hijos || []).map(String);
-    if (alumno) {
-      if (!hijos.includes(String(alumno))) {
-        return res.status(403).json({ error: "No autorizado para ver a este alumno" });
-      }
-    } else {
-      // si no pide alumno, devolvemos solo asistencias de sus hijos
-      filtro.alumno = { $in: hijos };
-    }
+    const data = await Asistencia.find(filtro)
+      .sort({ fecha: -1 })
+      .populate("alumno","nombre email")
+      .populate("curso","nombre anio division");
+    res.json(data);
+  } catch (error) {
+    const status = error.status || 500;
+    res.status(status).json({ error: error.message || "Error al listar asistencias" });
   }
-  if (req.user.rol === "estudiante") {
-    // estudiante solo ve sus propias asistencias
-    filtro.alumno = req.user.uid;
-  }
-
-  const data = await Asistencia.find(filtro)
-    .sort({ fecha: -1 })
-    .populate("alumno","nombre email")
-    .populate("curso","nombre anio division");
-  res.json(data);
 });
 
 /**

--- a/frontend/src/pages/Asistencia.jsx
+++ b/frontend/src/pages/Asistencia.jsx
@@ -68,7 +68,6 @@ export default function Asistencia() {
         setCursosLoading(false);
       }
     })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [esDocenteOAdmin]);
 
   // Cargar alumnos del curso seleccionado
@@ -92,7 +91,7 @@ export default function Asistencia() {
           const data = await apiGet(`/api/asistencias?fecha=${fecha}&alumno=${user.id}`);
           setRegistros(data);
         }
-      } catch (e) {
+      } catch {
         // manejado por api.js con toast de error
       }
     })();
@@ -221,7 +220,7 @@ export default function Asistencia() {
         month: "long",
         year: "numeric",
       }).format(new Date(fecha));
-    } catch (error) {
+    } catch {
       return fecha;
     }
   }, [fecha]);


### PR DESCRIPTION
## Summary
- add an authenticated /api/asistencias/resumen endpoint that aggregates attendance states, tardies and pending justifications
- reuse shared filtering logic for attendance queries to enforce role-based access control
- surface live attendance metrics on the dashboard hero and highlights cards while polishing the attendance page hooks

## Testing
- npm run lint *(fails: existing react-refresh/only-export-components rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_68e471057afc8324bc03ec7cd0248678