### PR TITLE
Improve course selector and targeted announcements

### DIFF
--- a/backend/models/anuncio.js
+++ b/backend/models/anuncio.js
@@ -6,11 +6,12 @@ const anuncioSchema = new mongoose.Schema(
     contenido: { type: String, required: true },
     curso: { type: mongoose.Schema.Types.ObjectId, ref: "Curso", required: true },
     autor: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+    alumno: { type: mongoose.Schema.Types.ObjectId, ref: "User" },
     visiblePara: {
       type: String,
       enum: ["todos", "padres", "estudiantes", "docentes"],
       default: "todos",
-    }
+    },
     // más adelante podemos sumar: fechaHasta, archivos, etiquetas, etc.
   },
   { timestamps: true }

--- a/backend/routes/anuncios.js
+++ b/backend/routes/anuncios.js
@@ -1,19 +1,33 @@
 import { Router } from "express";
 import { requireAuth, requireRole } from "../middleware/auth.js";
 import Anuncio from "../models/anuncio.js";
+import Curso from "../models/Curso.js";
 
 const router = Router();
 
 /**
  * Crear anuncio (docente o admin)
- * body: { titulo, contenido, curso, visiblePara }
+ * body: { titulo, contenido, curso, visiblePara, alumno? }
  */
 router.post("/", requireAuth, requireRole("docente", "admin"), async (req, res) => {
   try {
-    const { titulo, contenido, curso, visiblePara } = req.body;
+    const { titulo, contenido, curso, visiblePara, alumno } = req.body;
 
     if (!titulo || !contenido || !curso) {
       return res.status(400).json({ error: "Faltan campos obligatorios" });
+    }
+
+    const cursoDoc = await Curso.findById(curso).select("alumnos");
+    if (!cursoDoc) {
+      return res.status(404).json({ error: "Curso no encontrado" });
+    }
+
+    const alumnoId = typeof alumno === "string" ? alumno.trim() : undefined;
+    if (alumnoId) {
+      const pertenece = cursoDoc.alumnos.some((id) => id.equals(alumnoId));
+      if (!pertenece) {
+        return res.status(400).json({ error: "El estudiante no pertenece al curso" });
+      }
     }
 
     const anuncio = await Anuncio.create({
@@ -21,7 +35,8 @@ router.post("/", requireAuth, requireRole("docente", "admin"), async (req, res) 
       contenido,
       curso,
       visiblePara: visiblePara || "todos",
-      autor: req.user.uid
+      autor: req.user.uid,
+      alumno: alumnoId || undefined,
     });
 
     res.status(201).json(anuncio);
@@ -36,12 +51,30 @@ router.post("/", requireAuth, requireRole("docente", "admin"), async (req, res) 
  */
 router.get("/", requireAuth, async (req, res) => {
   try {
-    const { curso } = req.query;
-    const filtro = curso ? { curso } : {};
+    const { curso, alumno } = req.query;
+    const filtro = {};
+    if (curso) filtro.curso = curso;
+
+    const alumnoId = typeof alumno === "string" ? alumno.trim() : "";
+
+    if (alumnoId) {
+      filtro.$or = [{ alumno: null }, { alumno: alumnoId }];
+    } else if (req.user?.rol === "estudiante") {
+      filtro.$or = [
+        { alumno: null, visiblePara: { $in: ["todos", "estudiantes"] } },
+        { alumno: req.user.uid },
+      ];
+    } else if (req.user?.rol === "padre") {
+      filtro.$or = [
+        { alumno: null, visiblePara: { $in: ["todos", "padres"] } },
+      ];
+    }
+
     const anuncios = await Anuncio.find(filtro)
       .sort({ createdAt: -1 })
       .populate("autor", "nombre rol")
-      .populate("curso", "nombre anio division turno");
+      .populate("curso", "nombre anio division turno")
+      .populate("alumno", "nombre email rol");
 
     res.json(anuncios);
   } catch (e) {

--- a/frontend/src/components/ui/DropdownSelect.jsx
+++ b/frontend/src/components/ui/DropdownSelect.jsx
@@ -1,0 +1,125 @@
+import { Check, ChevronsUpDown } from "lucide-react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+
+export default function DropdownSelect({
+  label,
+  helper,
+  className = "",
+  buttonClassName = "",
+  placeholder = "Seleccionar…",
+  value,
+  onChange,
+  options = [],
+  disabled = false,
+}) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef(null);
+  const listId = useId();
+
+  const selected = useMemo(
+    () => options.find((option) => option.value === value) || null,
+    [options, value],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClickOutside(event) {
+      if (!containerRef.current?.contains(event.target)) {
+        setOpen(false);
+      }
+    }
+    function handleKey(event) {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleKey);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  function handleSelect(option) {
+    if (disabled) return;
+    onChange?.(option.value, option);
+    setOpen(false);
+  }
+
+  return (
+    <label ref={containerRef} className={`block space-y-1.5 ${className}`}>
+      {label && <div className="text-sm font-medium text-subtext/80">{label}</div>}
+      <div className="relative">
+        <button
+          type="button"
+          disabled={disabled}
+          className={`flex w-full items-center justify-between rounded-2xl border border-white/70 bg-white/90 px-4 py-2 text-left text-sm font-medium text-text shadow-soft transition focus:outline-none focus:ring-4 focus:ring-brand-400/30 disabled:cursor-not-allowed disabled:opacity-60 ${buttonClassName}`}
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          aria-controls={listId}
+          onClick={() => {
+            if (disabled) return;
+            setOpen((prev) => !prev);
+          }}
+        >
+          {selected ? (
+            <div className="flex flex-col">
+              <span className="text-sm font-semibold leading-tight text-text">{selected.title}</span>
+              {selected.subtitle && (
+                <span className="text-xs text-subtext">{selected.subtitle}</span>
+              )}
+            </div>
+          ) : (
+            <span className="text-sm text-subtext">{placeholder}</span>
+          )}
+          <ChevronsUpDown className="ml-3 h-4 w-4 flex-shrink-0 text-subtext/70" aria-hidden="true" />
+        </button>
+
+        {open && (
+          <ul
+            id={listId}
+            role="listbox"
+            className="absolute z-30 mt-2 max-h-64 w-full overflow-y-auto rounded-2xl border border-muted bg-white/95 p-1 shadow-2xl backdrop-blur"
+          >
+            {options.length === 0 ? (
+              <li className="px-4 py-3 text-sm text-subtext">Sin opciones disponibles</li>
+            ) : (
+              options.map((option) => {
+                const isActive = option.value === value;
+                return (
+                  <li key={option.value}>
+                    <button
+                      type="button"
+                      role="option"
+                      aria-selected={isActive}
+                      className={`flex w-full items-center justify-between gap-3 rounded-xl px-4 py-3 text-left text-sm transition focus:outline-none focus:ring-2 focus:ring-brand-400/40 ${
+                        isActive
+                          ? "bg-brand-100/70 text-brand-700"
+                          : "text-text hover:bg-brand-50"
+                      }`}
+                      onClick={() => handleSelect(option)}
+                    >
+                      <div className="flex flex-col">
+                        <span className="font-semibold leading-tight">{option.title}</span>
+                        {option.subtitle && (
+                          <span className="text-xs text-subtext">{option.subtitle}</span>
+                        )}
+                      </div>
+                      {isActive && (
+                        <Check className="h-4 w-4 flex-shrink-0 text-brand-600" aria-hidden="true" />
+                      )}
+                    </button>
+                  </li>
+                );
+              })
+            )}
+          </ul>
+        )}
+      </div>
+      {helper && <div className="text-xs text-subtext">{helper}</div>}
+    </label>
+  );
+}

--- a/frontend/src/pages/Asistencia.jsx
+++ b/frontend/src/pages/Asistencia.jsx
@@ -9,7 +9,7 @@ import Badge from "../components/ui/Badge";
 import Modal from "../components/ui/Modal";
 import { useToast } from "../components/ui/Toast";
 import Input from "../components/ui/Input";
-import Select from "../components/ui/Select";
+import DropdownSelect from "../components/ui/DropdownSelect";
 import { Table, THead, TRow, TH, TD } from "../components/ui/Table";
 import EmptyState from "../components/ui/EmptyState";
 import Skeleton from "../components/ui/Skeleton";
@@ -224,6 +224,15 @@ export default function Asistencia() {
       return fecha;
     }
   }, [fecha]);
+  const cursoOptions = useMemo(
+    () =>
+      cursos.map((curso) => ({
+        value: curso._id,
+        title: curso.nombre,
+        subtitle: `${curso.anio}° ${curso.division || ""}${curso.turno ? ` · Turno ${curso.turno}` : ""}`,
+      })),
+    [cursos],
+  );
 
   const estadoColorMap = {
     presente: "success",
@@ -291,14 +300,17 @@ export default function Asistencia() {
                 {esDocenteOAdmin ? (
                   cursosLoading ? (
                     <Skeleton className="h-11 w-full rounded-2xl" />
+                  ) : cursos.length === 0 ? (
+                    <div className="rounded-2xl border border-dashed border-brand-200 bg-brand-500/5 p-4 text-sm text-subtext">
+                      Aún no hay cursos asignados.
+                    </div>
                   ) : (
-                    <Select value={cursoSel} onChange={(e) => setCursoSel(e.target.value)}>
-                      {cursos.map((c) => (
-                        <option key={c._id} value={c._id}>
-                          {c.nombre} — {c.anio}° {c.division || ""}
-                        </option>
-                      ))}
-                    </Select>
+                    <DropdownSelect
+                      value={cursoSel}
+                      onChange={(next) => setCursoSel(next)}
+                      options={cursoOptions}
+                      placeholder="Elegí un curso"
+                    />
                   )
                 ) : (
                   <div className="rounded-2xl border border-dashed border-brand-200 bg-brand-500/5 p-4 text-sm text-subtext">


### PR DESCRIPTION
## Summary
- add a stylized DropdownSelect component and replace the course filter on asistencia with the new control
- allow docentes/admins to filter dashboard announcements by student and create student-targeted messages with updated modal UI
- extend anuncios persistence and API to store optional student recipients and limit visibility by role

## Testing
- `npm run lint` *(fails: existing react-refresh/only-export-components errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f1bf2e5c83248095327c4a126456