### PR TITLE
Improve announcements modal and responsive layout

### DIFF
--- a/frontend/src/components/Shell.jsx
+++ b/frontend/src/components/Shell.jsx
@@ -201,7 +201,7 @@ export default function Shell({
         <main className="flex min-h-screen flex-1 flex-col">
           <div className="border-b border-muted bg-surface/90 backdrop-blur supports-[backdrop-filter]:bg-surface/80">
             <div className="flex flex-col gap-4 px-5 py-4 sm:px-8 sm:py-5 lg:flex-row lg:items-center lg:justify-between">
-              <div className="flex items-start gap-4">
+              <div className="flex min-w-0 items-start gap-4">
                 <button
                   type="button"
                   onClick={() => setSidebarOpen(true)}
@@ -211,7 +211,7 @@ export default function Shell({
                   <Menu className="h-5 w-5" aria-hidden="true" />
                 </button>
 
-                <div>
+                <div className="min-w-0">
                   <p className="text-xs font-semibold uppercase tracking-wide text-subtext">
                     Inicio · {currentTab?.label || "Panel"}
                   </p>
@@ -222,7 +222,7 @@ export default function Shell({
                 </div>
               </div>
 
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
+              <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
                 {headerActions}
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end sm:gap-3">
                   <label className="flex w-full items-center gap-3 rounded-full bg-white px-4 py-2 shadow-soft ring-1 ring-transparent transition focus-within:ring-2 focus-within:ring-brand-200 sm:max-w-sm lg:min-w-[22rem]">
@@ -234,7 +234,7 @@ export default function Shell({
                       className="w-full border-0 bg-transparent text-sm text-text placeholder:text-subtext focus:outline-none"
                     />
                   </label>
-                  <div className="flex items-center justify-end gap-2">
+                  <div className="flex flex-wrap items-center justify-end gap-2">
                     {resolvedQuickActions.map((action) => {
                       const { icon } = action;
 

--- a/frontend/src/components/ui/Badge.jsx
+++ b/frontend/src/components/ui/Badge.jsx
@@ -1,4 +1,4 @@
-export default function Badge({ children, color="brand" }) {
+export default function Badge({ children, color = "brand", className = "" }) {
   const palette = {
     brand: "bg-brand-500/20 text-brand-700 ring-1 ring-brand-500/25",
     neutral: "bg-muted text-subtext ring-1 ring-black/10",
@@ -6,8 +6,9 @@ export default function Badge({ children, color="brand" }) {
     warn: "bg-amber-500/20 text-amber-800 ring-1 ring-amber-500/25",
     danger: "bg-red-500/20 text-red-800 ring-1 ring-red-500/25",
   };
+  const tones = palette[color] || palette.brand;
   return (
-    <span className={`px-2 py-1 rounded-lg text-xs ${palette[color]}`}>
+    <span className={`rounded-lg px-2 py-1 text-xs ${tones} ${className}`}>
       {children}
     </span>
   );

--- a/frontend/src/components/ui/Card.jsx
+++ b/frontend/src/components/ui/Card.jsx
@@ -15,12 +15,12 @@ export function Card({ children, className = "" }) {
 
 export function CardHeader({ title, subtitle, actions }) {
   return (
-    <div className="p-4 border-b border-muted flex items-start justify-between gap-3">
-      <div>
-        <div className="font-semibold">{title}</div>
+    <div className="flex flex-col gap-3 border-b border-muted p-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
+        <div className="font-semibold break-words">{title}</div>
         {subtitle && <div className="text-sm text-subtext">{subtitle}</div>}
       </div>
-      {actions && <div className="shrink-0">{actions}</div>}
+      {actions && <div className="shrink-0 sm:self-end">{actions}</div>}
     </div>
   );
 }

--- a/frontend/src/components/ui/Modal.jsx
+++ b/frontend/src/components/ui/Modal.jsx
@@ -2,8 +2,8 @@
 export default function Modal({ open, title, onClose, actions, children }) {
   if (!open) return null;
   return (
-    <div className="fixed inset-0 z-[9998] bg-slate-900/30 backdrop-blur-sm grid place-items-center p-4">
-      <div className="w-full max-w-xl rounded-3xl border border-white/60 bg-white/95 shadow-[0_20px_45px_-20px_rgba(15,23,42,0.45)]">
+    <div className="fixed inset-0 z-[9998] flex items-center justify-center overflow-y-auto bg-slate-900/30 p-4 backdrop-blur-sm sm:p-6">
+      <div className="flex w-full max-w-xl flex-col overflow-hidden rounded-3xl border border-white/60 bg-white/95 shadow-[0_20px_45px_-20px_rgba(15,23,42,0.45)]" style={{ maxHeight: "min(90vh, 40rem)" }}>
         <div className="flex items-center justify-between gap-3 border-b border-white/60 bg-gradient-to-r from-white/80 to-white/40 p-5 rounded-t-3xl">
           <div className="font-semibold text-text">{title}</div>
           <button
@@ -13,9 +13,9 @@ export default function Modal({ open, title, onClose, actions, children }) {
             ✕
           </button>
         </div>
-        <div className="p-5 text-sm text-text">{children}</div>
+        <div className="flex-1 overflow-y-auto p-5 text-sm text-text">{children}</div>
         {actions && (
-          <div className="flex justify-end gap-3 border-t border-white/60 bg-white/60 px-5 py-4 rounded-b-3xl">
+          <div className="flex flex-col gap-3 border-t border-white/60 bg-white/70 px-5 py-4 rounded-b-3xl sm:flex-row sm:justify-end">
             {actions}
           </div>
         )}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -214,18 +214,23 @@ export default function Dashboard() {
           ) : (
             <ul className="space-y-3">
               {anuncios.map((a) => (
-                <li key={a._id} className="p-4 rounded-2xl border border-muted bg-surface hover:bg-card transition">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2 text-subtext">
+                <li
+                  key={a._id}
+                  className="rounded-2xl border border-muted bg-surface p-4 transition hover:bg-card"
+                >
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex flex-wrap items-center gap-2 text-subtext">
                       <Megaphone className="h-4 w-4" aria-hidden="true" />
                       <span>{a.curso?.nombre}</span>
                       <span>•</span>
                       <span>{new Date(a.createdAt).toLocaleString("es-AR")}</span>
                     </div>
-                    <Badge color="brand">{a.autor?.rol}</Badge>
+                    <Badge color="brand" className="w-fit">
+                      {a.autor?.rol}
+                    </Badge>
                   </div>
                   <div className="mt-1 text-lg font-semibold">{a.titulo}</div>
-                  <div className="text-sm text-text/90 whitespace-pre-line">{a.contenido}</div>
+                  <div className="break-words whitespace-pre-line text-sm text-text/90">{a.contenido}</div>
                   {a.alumno ? (
                     <div className="mt-2 inline-flex items-center gap-1 rounded-full bg-brand-500/10 px-3 py-1 text-xs font-semibold text-brand-700">
                       🎯 Dirigido a {a.alumno.nombre}
@@ -424,7 +429,7 @@ function HeroSummary({
   }, [alumnos]);
 
   return (
-    <div className="relative overflow-hidden rounded-3xl border border-muted/50 bg-gradient-to-br from-brand-100 via-brand-50 to-white p-8 text-text shadow-soft">
+    <div className="relative overflow-hidden rounded-3xl border border-muted/50 bg-gradient-to-br from-brand-100 via-brand-50 to-white p-6 text-text shadow-soft sm:p-8">
       <div className="relative z-10 flex flex-col gap-8 lg:gap-10">
         <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
           <div className="max-w-xl">
@@ -472,7 +477,7 @@ function HeroSummary({
                 />
               ) : null}
             </div>
-            <div className="grid w-full grid-cols-2 gap-3">
+            <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2">
               <div className="rounded-2xl border border-white/60 bg-white/90 p-3 shadow-sm">
                 <p className="text-xs font-medium uppercase tracking-wide text-subtext/80">Participación</p>
                 {resumenLoading ? (
@@ -506,7 +511,7 @@ function HeroSummary({
         </div>
 
         {onCreate ? (
-          <div className="flex flex-wrap items-center gap-3">
+          <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
             <Button onClick={onCreate} className="shadow-soft">
               Publicar anuncio
             </Button>
@@ -551,11 +556,11 @@ function UpcomingEvents() {
 
   return (
     <div className="rounded-3xl border border-muted/60 bg-card/70 p-6 shadow-soft">
-      <div className="flex items-center gap-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <span className="rounded-full bg-brand/10 p-2 text-brand">
           <CalendarDays className="h-5 w-5" aria-hidden="true" />
         </span>
-        <div>
+        <div className="text-left">
           <h3 className="text-lg font-semibold text-text">Próximos eventos</h3>
           <p className="text-sm text-subtext">Agenda destacada para los próximos días.</p>
         </div>
@@ -565,7 +570,7 @@ function UpcomingEvents() {
         {events.map((event) => (
           <li
             key={event.id}
-            className="flex items-center justify-between rounded-2xl border border-muted/50 bg-white/50 px-4 py-3 text-sm text-subtext backdrop-blur"
+            className="flex flex-col gap-3 rounded-2xl border border-muted/50 bg-white/50 px-4 py-3 text-sm text-subtext backdrop-blur sm:flex-row sm:items-center sm:justify-between"
           >
             <div>
               <div className="font-semibold text-text">{event.title}</div>
@@ -645,7 +650,7 @@ function ProgressHighlights({ resumen, loading }) {
                 key={id}
                 className="rounded-2xl border border-muted/40 bg-white/60 p-4 backdrop-blur transition hover:border-brand/40"
               >
-                <div className="flex items-center justify-between">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <div>
                     <div className="text-sm font-medium text-subtext">{label}</div>
                     <div className="mt-1 text-2xl font-semibold text-text">
@@ -653,7 +658,7 @@ function ProgressHighlights({ resumen, loading }) {
                     </div>
                     <p className="text-xs text-subtext">{helper}</p>
                   </div>
-                  <span className={`rounded-full bg-brand/5 p-2 ${tone}`}>
+                  <span className={`inline-flex h-10 w-10 items-center justify-center rounded-full bg-brand/5 ${tone}`}>
                     <Icon className="h-5 w-5" aria-hidden="true" />
                   </span>
                 </div>


### PR DESCRIPTION
## Summary
- allow the announcements modal to scroll on small screens so the full form remains accessible
- adjust dashboard cards, badges, and highlight blocks to wrap content gracefully on small widths
- update the shell header layout to better accommodate quick actions and user info on narrow viewports

## Testing
- npm run lint *(fails: existing react-refresh/only-export-components errors in Toast.jsx, AuthProvider.jsx, main.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e55b7e3638832480ee7c4398ec3f75