### PR TITLE
Agregar importación de estudiantes desde planillas

### DIFF
--- a/backend/middleware/upload.js
+++ b/backend/middleware/upload.js
@@ -13,11 +13,32 @@ const storage = multer.diskStorage({
   },
 });
 
-export const upload = multer({
-  storage,
-  limits: { fileSize: 5 * 1024 * 1024 }, // 5 MB
-  fileFilter: (_req, file, cb) => {
-    const ok = ["application/pdf", "image/jpeg", "image/png"].includes(file.mimetype);
-    cb(ok ? null : new Error("Tipo de archivo no permitido (solo PDF/JPG/PNG)"));
-  },
+function buildUploader({ allowedTypes, maxSizeMB, errorMessage }) {
+  return multer({
+    storage,
+    limits: { fileSize: maxSizeMB * 1024 * 1024 },
+    fileFilter: (_req, file, cb) => {
+      const ok = allowedTypes.includes(file.mimetype);
+      cb(ok ? null : new Error(errorMessage));
+    },
+  });
+}
+
+export const upload = buildUploader({
+  allowedTypes: ["application/pdf", "image/jpeg", "image/png"],
+  maxSizeMB: 5,
+  errorMessage: "Tipo de archivo no permitido (solo PDF/JPG/PNG)",
+});
+
+export const uploadExcel = buildUploader({
+  allowedTypes: [
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.ms-excel",
+    "application/vnd.ms-excel.sheet.macroEnabled.12",
+    "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
+    "text/csv",
+    "text/plain",
+  ],
+  maxSizeMB: 5,
+  errorMessage: "Tipo de archivo no permitido (solo Excel o CSV)",
 });

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,7 +14,8 @@
         "express": "^4.19.2",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.6.0",
-        "multer": "^2.0.2"
+        "multer": "^2.0.2",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "nodemon": "^3.1.0"
@@ -55,6 +56,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/anymatch": {
@@ -260,6 +270,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -283,6 +306,15 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/concat-map": {
@@ -354,6 +386,18 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/debug": {
@@ -601,6 +645,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fresh": {
@@ -1577,6 +1630,18 @@
         "memory-pager": "^1.0.2"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -1739,6 +1804,45 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xtend": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,8 @@
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.6.0",
-    "multer": "^2.0.2"
+    "multer": "^2.0.2",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "nodemon": "^3.1.0"

--- a/backend/routes/cursos.js
+++ b/backend/routes/cursos.js
@@ -1,6 +1,11 @@
 import { Router } from "express";
+import fs from "fs/promises";
+import bcrypt from "bcryptjs";
+import xlsx from "xlsx";
 import Curso from "../models/Curso.js";
+import User from "../models/User.js";
 import { requireAuth, requireRole } from "../middleware/auth.js";
+import { uploadExcel } from "../middleware/upload.js";
 
 const router = Router();
 
@@ -20,6 +25,102 @@ router.get("/", requireAuth, async (req, res) => {
   res.json(cursos);
 });
 
+function pickValue(row, keys) {
+  for (const key of keys) {
+    const value = row[key];
+    if (value === undefined || value === null) continue;
+    const str = String(value).trim();
+    if (str) return str;
+  }
+  return "";
+}
+
+function buildNombre(row) {
+  const nombre = pickValue(row, [
+    "Nombre",
+    "nombre",
+    "Nombres",
+    "nombres",
+    "First Name",
+    "FirstName",
+    "first_name",
+    "firstName",
+  ]);
+  const apellido = pickValue(row, [
+    "Apellido",
+    "apellido",
+    "Apellidos",
+    "apellidos",
+    "Last Name",
+    "LastName",
+    "last_name",
+    "lastName",
+  ]);
+
+  if (nombre || apellido) {
+    return `${nombre} ${apellido}`.trim();
+  }
+
+  return pickValue(row, [
+    "Nombre completo",
+    "nombre completo",
+    "Alumno",
+    "alumno",
+    "Estudiante",
+    "estudiante",
+    "Name",
+    "name",
+  ]);
+}
+
+function buildEmail(row) {
+  const raw = pickValue(row, [
+    "Email",
+    "email",
+    "Correo",
+    "correo",
+    "Correo electrónico",
+    "correo electrónico",
+    "Mail",
+    "mail",
+  ]);
+  return raw.toLowerCase();
+}
+
+function buildPassword(row, email) {
+  const explicit = pickValue(row, [
+    "Password",
+    "password",
+    "Contraseña",
+    "contraseña",
+    "Contrasena",
+    "contrasena",
+    "Clave",
+    "clave",
+  ]);
+  if (explicit) return explicit;
+
+  const documento = pickValue(row, [
+    "DNI",
+    "dni",
+    "Documento",
+    "documento",
+    "Legajo",
+    "legajo",
+  ]);
+  if (documento) return documento;
+
+  if (email && email.includes("@")) {
+    return email.split("@")[0];
+  }
+
+  return `temporal-${Math.random().toString(36).slice(-8)}`;
+}
+
+function isRowEmpty(row) {
+  return Object.values(row).every((value) => String(value ?? "").trim() === "");
+}
+
 // Agregar alumno a un curso (admin o docente)
 router.post("/:id/agregar-alumno", requireAuth, requireRole("admin", "docente"), async (req, res) => {
   const { alumnoId } = req.body;
@@ -30,6 +131,124 @@ router.post("/:id/agregar-alumno", requireAuth, requireRole("admin", "docente"),
   ).populate("docentes alumnos", "nombre email rol");
   res.json(curso);
 });
+
+// Importar alumnos desde un Excel/CSV
+router.post(
+  "/:id/importar-alumnos",
+  requireAuth,
+  requireRole("admin", "docente"),
+  uploadExcel.single("archivo"),
+  async (req, res) => {
+    if (!req.file) {
+      return res.status(400).json({ error: "Subí un archivo Excel o CSV." });
+    }
+
+    try {
+      const curso = await Curso.findById(req.params.id);
+      if (!curso) {
+        return res.status(404).json({ error: "Curso no encontrado" });
+      }
+
+      const workbook = xlsx.readFile(req.file.path);
+      const [firstSheetName] = workbook.SheetNames;
+      if (!firstSheetName) {
+        return res.status(400).json({ error: "El archivo no contiene datos." });
+      }
+
+      const rows = xlsx.utils.sheet_to_json(workbook.Sheets[firstSheetName], { defval: "" });
+      const summary = {
+        procesados: 0,
+        creados: 0,
+        actualizados: 0,
+        vinculados: 0,
+        yaAsignados: 0,
+        omitidos: [],
+        credencialesNuevas: [],
+      };
+
+      const alumnoIds = new Set(curso.alumnos.map((id) => id.toString()));
+
+      for (let index = 0; index < rows.length; index += 1) {
+        const row = rows[index];
+        if (isRowEmpty(row)) continue;
+
+        summary.procesados += 1;
+
+        const nombre = buildNombre(row);
+        const email = buildEmail(row);
+        const emailValido = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+
+        if (!nombre || !emailValido) {
+          summary.omitidos.push({ fila: index + 2, motivo: "Falta nombre o email válido" });
+          continue;
+        }
+
+        let user = await User.findOne({ email });
+        let passwordPlano = null;
+        let updated = false;
+
+        if (!user) {
+          passwordPlano = buildPassword(row, email);
+          const passwordHash = await bcrypt.hash(passwordPlano, 10);
+          user = await User.create({
+            nombre,
+            email,
+            passwordHash,
+            rol: "estudiante",
+          });
+          summary.creados += 1;
+          summary.credencialesNuevas.push({ email: user.email, passwordTemporal: passwordPlano });
+        } else {
+          const updates = {};
+          if (user.rol !== "estudiante") {
+            updates.rol = "estudiante";
+          }
+          if (nombre && user.nombre !== nombre) {
+            updates.nombre = nombre;
+          }
+
+          if (Object.keys(updates).length > 0) {
+            user = await User.findByIdAndUpdate(user._id, { $set: updates }, { new: true });
+            summary.actualizados += 1;
+            updated = true;
+          }
+
+        }
+
+        const userIdStr = user._id.toString();
+        const yaEstaba = alumnoIds.has(userIdStr);
+
+        const result = await Curso.updateOne(
+          { _id: curso._id },
+          { $addToSet: { alumnos: user._id } },
+        );
+
+        if (result.modifiedCount > 0 && !yaEstaba) {
+          summary.vinculados += 1;
+          alumnoIds.add(userIdStr);
+        } else if (yaEstaba) {
+          summary.yaAsignados += 1;
+        } else if (!yaEstaba) {
+          alumnoIds.add(userIdStr);
+        }
+      }
+
+      const cursoActualizado = await Curso.findById(curso._id).populate(
+        "docentes alumnos",
+        "nombre email rol",
+      );
+
+      res.json({ curso: cursoActualizado, resumen: summary });
+    } catch (error) {
+      console.error("Error importando alumnos:", error);
+      res.status(500).json({ error: "No se pudo importar la lista de estudiantes" });
+    } finally {
+      if (req.file) {
+        await fs.unlink(req.file.path).catch(() => {});
+      }
+    }
+  },
+);
 
 // Agregar docente a un curso (admin)
 router.post("/:id/agregar-docente", requireAuth, requireRole("admin"), async (req, res) => {

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -51,13 +51,18 @@ export default function Dashboard() {
       setLoading(true);
       try {
         const list = await apiGet("/api/cursos");
-        setCursos(list);
-        if (list[0]?._id) setCursoSel(list[0]._id);
+        setCursos(Array.isArray(list) ? list : []);
+        setCursoSel(list?.[0]?._id || "");
+      } catch (error) {
+        console.error("No se pudieron cargar los cursos", error);
+        setCursos([]);
+        setCursoSel("");
+        toast?.show?.(error?.error || "No se pudieron cargar los cursos", "error");
       } finally {
         setLoading(false);
       }
     })();
-  }, []);
+  }, [toast]);
 
   useEffect(() => {
     setAlumnoSel("todos");


### PR DESCRIPTION
## Summary
- add reusable multer configuration for Excel/CSV uploads and include xlsx dependency
- implement a backend endpoint to importar-alumnos that parses spreadsheets, crea usuarios estudiantes y los vincula al curso con resumen de la operación
- update the Estudiantes UI to permitir cargar planillas, mostrar el resultado del import y manejar errores de carga de cursos tanto allí como en el dashboard

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e56719b0148324866ca615b4c1344f