### PR TITLE
Fix repeated toast-triggered course fetches

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -8,9 +8,12 @@ import { setApiToast } from "./api";
 
 function ApiToastBridge() {
   const toast = useToast();
+  const toastShow = toast?.show;
   useEffect(() => {
-    setApiToast(toast.show);
-  }, [toast]);
+    if (toastShow) {
+      setApiToast(toastShow);
+    }
+  }, [toastShow]);
   return null;
 }
 

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -18,6 +18,7 @@ import Skeleton from "../components/ui/Skeleton";
 export default function Dashboard() {
   const { user } = useAuth();
   const toast = useToast();
+  const toastShow = toast?.show;
 
   const [cursos, setCursos] = useState([]);
   const [cursoSel, setCursoSel] = useState("");
@@ -57,12 +58,12 @@ export default function Dashboard() {
         console.error("No se pudieron cargar los cursos", error);
         setCursos([]);
         setCursoSel("");
-        toast?.show?.(error?.error || "No se pudieron cargar los cursos", "error");
+        toastShow?.(error?.error || "No se pudieron cargar los cursos", "error");
       } finally {
         setLoading(false);
       }
     })();
-  }, [toast]);
+  }, [toastShow]);
 
   useEffect(() => {
     setAlumnoSel("todos");
@@ -108,11 +109,11 @@ export default function Dashboard() {
 
   async function crearAnuncio() {
     if (!cursoSel || !titulo.trim() || !contenido.trim()) {
-      toast.show("Completá título y contenido", "error");
+      toastShow?.("Completá título y contenido", "error");
       return;
     }
     if (alcance === "alumno" && !alumnoDestino) {
-      toast.show("Elegí un estudiante destinatario", "error");
+      toastShow?.("Elegí un estudiante destinatario", "error");
       return;
     }
     setSaving(true);
@@ -140,7 +141,7 @@ export default function Dashboard() {
       list.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
       setAnuncios(list);
 
-      toast.show("Anuncio publicado");
+      toastShow?.("Anuncio publicado");
     } finally {
       setSaving(false);
     }

--- a/frontend/src/pages/Estudiantes.jsx
+++ b/frontend/src/pages/Estudiantes.jsx
@@ -33,6 +33,7 @@ export default function Estudiantes() {
   const [resumenes, setResumenes] = useState({});
 
   const toast = useToast();
+  const toastShow = toast?.show;
 
   const autorizado = user?.rol === "admin" || user?.rol === "docente";
 
@@ -50,13 +51,13 @@ export default function Estudiantes() {
         setCursos(Array.isArray(data) ? data : []);
       } catch (error) {
         console.error("No se pudieron cargar los cursos", error);
-        toast?.show?.(error?.error || "No se pudieron cargar los cursos", "error");
+        toastShow?.(error?.error || "No se pudieron cargar los cursos", "error");
         setCursos([]);
       } finally {
         setLoading(false);
       }
     })();
-  }, [autorizado, toast]);
+  }, [autorizado, toastShow]);
 
   async function importarAlumnos(file, cursoId) {
     if (!file || !cursoId) return;
@@ -80,9 +81,9 @@ export default function Estudiantes() {
           resumen.procesados === 0
             ? "No se encontraron filas para importar"
             : `Importación completada: ${resumen.vinculados} agregados, ${resumen.creados} nuevos.`;
-        toast?.show?.(mensaje, "success");
+        toastShow?.(mensaje, "success");
         if (resumen.omitidos?.length) {
-          toast?.show?.(
+          toastShow?.(
             `${resumen.omitidos.length} fila(s) omitida(s) por faltar datos. Revisá el detalle en el curso.`,
             "error",
           );
@@ -90,7 +91,7 @@ export default function Estudiantes() {
       }
     } catch (error) {
       console.error("Error importando alumnos", error);
-      toast?.show?.(error?.error || "No se pudo importar la lista", "error");
+      toastShow?.(error?.error || "No se pudo importar la lista", "error");
     } finally {
       setImportingFor(null);
     }


### PR DESCRIPTION
## Summary
- memoize the toast show callback before registering it with the API bridge to avoid repeated registrations
- reuse the stable toast show reference on the dashboard and students pages so failed course loads do not loop endlessly

## Testing
- npm run lint *(fails: existing react-refresh/only-export-components violations)*

------
https://chatgpt.com/codex/tasks/task_e_68e58d8ae8e08324ad349b7acf3e7ba7