### PR TITLE
Include first-year courses in seed script

### DIFF
--- a/backend/scripts/seedCursos.js
+++ b/backend/scripts/seedCursos.js
@@ -12,7 +12,7 @@ if (!MONGO_URI) {
   process.exit(1);
 }
 
-const anios = [2, 3, 4, 5];
+const anios = [1, 2, 3, 4, 5];
 const divisiones = ["1", "2"];
 const turnos = [
   { codigo: "TM", etiqueta: "Turno Mañana" },


### PR DESCRIPTION
## Summary
- update the course seeding script to generate first-year classes alongside existing entries
- ensure the seed covers all combinations from 1st to 5th year across both shifts and divisions

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e592c40e24832495c34da64285f9cd