### PR TITLE
Harden backend auth and password handling

### DIFF
--- a/backend/middleware/upload.js
+++ b/backend/middleware/upload.js
@@ -1,7 +1,8 @@
 import multer from "multer";
 import fs from "fs";
+import path from "path";
 
-export const UPLOAD_DIR = "uploads";
+export const UPLOAD_DIR = path.resolve(process.cwd(), "uploads");
 
 try {
   fs.mkdirSync(UPLOAD_DIR, { recursive: true });

--- a/backend/middleware/upload.js
+++ b/backend/middleware/upload.js
@@ -2,7 +2,14 @@ import multer from "multer";
 import fs from "fs";
 
 export const UPLOAD_DIR = "uploads";
-if (!fs.existsSync(UPLOAD_DIR)) fs.mkdirSync(UPLOAD_DIR);
+
+try {
+  fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+} catch (error) {
+  if (error.code !== "EEXIST") {
+    throw error;
+  }
+}
 
 const storage = multer.diskStorage({
   destination: (_req, _file, cb) => cb(null, UPLOAD_DIR),

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "dependencies": {
         "bcrypt": "^6.0.0",
-        "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
@@ -132,12 +131,6 @@
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/bcryptjs": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
-      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
-      "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "bcrypt": "^6.0.0",
-    "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/backend/routes/asistencias.js
+++ b/backend/routes/asistencias.js
@@ -6,6 +6,16 @@ import { upload } from "../middleware/upload.js";
 
 const router = Router();
 
+function handleCertificateUpload(req, res, next) {
+  upload.single("certificado")(req, res, (err) => {
+    if (!err) return next();
+    if (err.code === "LIMIT_FILE_SIZE") {
+      return res.status(413).json({ error: "El archivo supera el tamaño máximo permitido" });
+    }
+    return res.status(400).json({ error: err.message || "No se pudo procesar el archivo" });
+  });
+}
+
 function todayStr(date = new Date()) {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
@@ -223,7 +233,7 @@ router.get("/", requireAuth, async (req, res) => {
  * (padre o admin) Sube certificado y deja pendiente de aprobación.
  * form-data: fields { motivo }, file "certificado"
  */
-router.post("/:id/justificar", requireAuth, requireRole("padre","admin"), upload.single("certificado"), async (req,res) => {
+router.post("/:id/justificar", requireAuth, requireRole("padre","admin"), handleCertificateUpload, async (req,res) => {
   const { id } = req.params;
   const a = await Asistencia.findById(id);
   if (!a) return res.status(404).json({ error: "Asistencia no encontrada" });

--- a/backend/routes/cursos.js
+++ b/backend/routes/cursos.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import fs from "fs/promises";
-import bcrypt from "bcryptjs";
+import crypto from "crypto";
+import bcrypt from "bcrypt";
 import xlsx from "xlsx";
 import Curso from "../models/Curso.js";
 import User from "../models/User.js";
@@ -84,7 +85,7 @@ function buildEmail(row) {
     "Mail",
     "mail",
   ]);
-  return raw.toLowerCase();
+  return raw ? raw.toLowerCase() : "";
 }
 
 function buildPassword(row, email) {
@@ -114,7 +115,13 @@ function buildPassword(row, email) {
     return email.split("@")[0];
   }
 
-  return `temporal-${Math.random().toString(36).slice(-8)}`;
+  const random = crypto
+    .randomBytes(8)
+    .toString("base64")
+    .replace(/[^a-zA-Z0-9]/g, "")
+    .slice(0, 10);
+
+  return `temporal-${random || crypto.randomBytes(4).toString("hex")}`;
 }
 
 function isRowEmpty(row) {

--- a/backend/utils/password.js
+++ b/backend/utils/password.js
@@ -1,0 +1,63 @@
+import crypto from "crypto";
+
+export const MIN_PASSWORD_LENGTH = 8;
+
+function shuffle(array) {
+  for (let i = array.length - 1; i > 0; i -= 1) {
+    const j = crypto.randomInt(0, i + 1);
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}
+
+export function generateStrongPassword(length = 12) {
+  const letters = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+  const digits = "23456789";
+  const symbols = "!@#$%^&*";
+  const all = letters + digits + symbols;
+
+  const required = [
+    letters[crypto.randomInt(0, letters.length)],
+    letters[crypto.randomInt(0, letters.length)],
+    digits[crypto.randomInt(0, digits.length)],
+    symbols[crypto.randomInt(0, symbols.length)],
+  ];
+
+  while (required.length < length) {
+    required.push(all[crypto.randomInt(0, all.length)]);
+  }
+
+  return shuffle(required).join("").slice(0, length);
+}
+
+export function isPasswordStrong(password) {
+  const value = typeof password === "string" ? password.trim() : "";
+  return (
+    value.length >= MIN_PASSWORD_LENGTH &&
+    /[A-Za-z]/.test(value) &&
+    /\d/.test(value)
+  );
+}
+
+export function enforcePasswordPolicy(candidate, options = {}) {
+  const maxLength = options.maxLength || 64;
+  const base = typeof candidate === "string" ? candidate.trim() : "";
+  if (isPasswordStrong(base)) {
+    return base.slice(0, maxLength);
+  }
+
+  if (!base) {
+    return generateStrongPassword(Math.min(16, maxLength));
+  }
+
+  const sanitized = base.replace(/\s+/g, "");
+  const mixed = `${sanitized}${generateStrongPassword(Math.min(12, maxLength))}`
+    .replace(/[^A-Za-z0-9!@#$%^&*]/g, "")
+    .slice(0, maxLength);
+
+  if (isPasswordStrong(mixed)) {
+    return mixed;
+  }
+
+  return generateStrongPassword(Math.min(16, maxLength));
+}

--- a/frontend/src/pages/Estudiantes.jsx
+++ b/frontend/src/pages/Estudiantes.jsx
@@ -371,6 +371,21 @@ function ResumenImport({ resumen }) {
             {resumen.credencialesNuevas.map((item) => (
               <li key={item.email} className="rounded-lg bg-brand-100/60 px-2 py-1">
                 <span className="font-medium text-text">{item.email}</span>: {item.passwordTemporal}
+                {item.origen ? (
+                  <span className="ml-1 text-[11px] uppercase tracking-wide text-brand-600">
+                    ({
+                      item.origen === "planilla"
+                        ? "planilla"
+                        : item.origen === "fortalecida"
+                        ? "fortalecida"
+                        : item.origen === "documento"
+                        ? "desde documento"
+                        : item.origen === "email"
+                        ? "basada en email"
+                        : "generada"
+                    })
+                  </span>
+                ) : null}
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- sanitize registration and login payloads while enforcing minimum password length and defaulting new users to the padre role
- switch backend password hashing to bcrypt only and generate secure random temporary passwords when importing alumnos
- harden upload directory setup and drop the unused bcryptjs dependency

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e597a35cf48324a53389c9c0869b41